### PR TITLE
feat(Drive): emit event when the initial target value is reached

### DIFF
--- a/Runtime/SharedResources/Scripts/Driver/Drive.cs
+++ b/Runtime/SharedResources/Scripts/Driver/Drive.cs
@@ -389,6 +389,13 @@
             Facade.TargetValue = cachedTargetValue;
             Facade.DriveSpeed = cachedDriveSpeed;
             SetUp();
+
+            if (!EmitEvents)
+            {
+                return;
+            }
+
+            Facade.InitialTargetValueReached?.Invoke(NormalizedValue);
         }
     }
 }

--- a/Runtime/SharedResources/Scripts/Driver/DriveFacade.cs
+++ b/Runtime/SharedResources/Scripts/Driver/DriveFacade.cs
@@ -50,6 +50,11 @@
         [DocumentedByXml]
         public DriveUnityEvent NormalizedValueChanged = new DriveUnityEvent();
         /// <summary>
+        /// Emitted when <see cref="InitialTargetValue"/> has been reached by the control.
+        /// </summary>
+        [DocumentedByXml]
+        public DriveUnityEvent InitialTargetValueReached = new DriveUnityEvent();
+        /// <summary>
         /// Emitted when <see cref="TargetValue"/> has been reached by the control.
         /// </summary>
         [DocumentedByXml]


### PR DESCRIPTION
The new InitialTargetValueReached event is emitted when the initial
target value is reached and is useful for setting up initial
configuration as by default the initial target value process will not
emit any events even when the target value is reached so this new
InitialTargetValueReached event can be used to set up any initial
state required by the control.