### PR TITLE
fix(Drive): use actual value for initial start drive speed

### DIFF
--- a/Runtime/SharedResources/Scripts/Driver/Drive.cs
+++ b/Runtime/SharedResources/Scripts/Driver/Drive.cs
@@ -72,6 +72,10 @@
         public FloatRange DriveLimits { get; protected set; }
 
         /// <summary>
+        /// The value to set the drive speed to when driving the control to the initial start value.
+        /// </summary>
+        protected const float initialValueDriveSpeed = 5000f;
+        /// <summary>
         /// The previous state of <see cref="Value"/>.
         /// </summary>
         protected float previousValue = float.MaxValue;
@@ -288,7 +292,7 @@
         /// </summary>
         protected virtual void EmitNormalizedValueChanged()
         {
-            if (isMovingToInitialTargetValue && NormalizedValue.ApproxEquals(Facade.InitialTargetValue))
+            if (isMovingToInitialTargetValue && NormalizedValue.ApproxEquals(Facade.InitialTargetValue, TargetValueReachedThreshold))
             {
                 ResetToCacheAfterReachedInitialTargetValue();
                 return;
@@ -373,7 +377,7 @@
             EmitEvents = false;
             Facade.MoveToTargetValue = true;
             Facade.TargetValue = Facade.InitialTargetValue;
-            Facade.DriveSpeed = float.MaxValue;
+            Facade.DriveSpeed = initialValueDriveSpeed;
             SetUp();
         }
 


### PR DESCRIPTION
Using a drive speed that is too high causes problems with Unity joints
and can cause them to break their restrictions.

Instead of using a float max value, it now uses just a high value that
is fast enough to not notice but not fast enough to break the Unity
joints system.

Whilst 5000f seems like a magic number, it's just a number that was
decided that fell into the category of not breaking things but being
fast enough to not notice.