### PR TITLE
feat(Driver): add methods for properties in UnityEvents

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -4,7 +4,6 @@ update_configs:
     directory: /
     update_schedule: live
     default_reviewers:
-      - bddckr
       - thestonefox
     default_labels:
       - dependency-update

--- a/Documentation/API/AngularDriver/AngularDrive.md
+++ b/Documentation/API/AngularDriver/AngularDrive.md
@@ -21,6 +21,7 @@ The basis to drive a control in a rotational angle.
   * [ActualTargetAngle]
   * [CurrentActualAngle]
   * [PreviousActualAngle]
+  * [ResetRotationsOnSetup]
 * [Methods]
   * [ApplyExistingAngularVelocity(Single)]
   * [ApplyLimits()]
@@ -35,6 +36,7 @@ The basis to drive a control in a rotational angle.
   * [MatchActualTargetAngle(Single)]
   * [Process()]
   * [ProcessAutoDrive(Single)]
+  * [ResetRotations()]
   * [SetUpInternals()]
 * [Implements]
 
@@ -97,6 +99,10 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.SetUp()]
 
 [Drive<AngularDriveFacade, AngularDrive>.Process()]
+
+[Drive<AngularDriveFacade, AngularDrive>.SetDriveLimits()]
+
+[Drive<AngularDriveFacade, AngularDrive>.SetAxisDirection()]
 
 [Drive<AngularDriveFacade, AngularDrive>.ProcessDriveSpeed(Single, Boolean)]
 
@@ -272,6 +278,16 @@ The previous rotation angle of the control.
 
 ```
 protected float PreviousActualAngle { get; }
+```
+
+#### ResetRotationsOnSetup
+
+The joint being used to drive the rotation.
+
+##### Declaration
+
+```
+public bool ResetRotationsOnSetup { get; set; }
 ```
 
 ### Methods
@@ -491,6 +507,16 @@ protected abstract void ProcessAutoDrive(float driveSpeed)
 | --- | --- | --- |
 | System.Single | driveSpeed | The speed to automatically rotate the drive. |
 
+#### ResetRotations()
+
+Resets the Transform rotation data.
+
+##### Declaration
+
+```
+public virtual void ResetRotations()
+```
+
 #### SetUpInternals()
 
 Performs any required internal setup.
@@ -535,6 +561,8 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.cachedDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedDriveSpeed
 [Drive<AngularDriveFacade, AngularDrive>.SetUp()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetUp
 [Drive<AngularDriveFacade, AngularDrive>.Process()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Process
+[Drive<AngularDriveFacade, AngularDrive>.SetDriveLimits()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetDriveLimits
+[Drive<AngularDriveFacade, AngularDrive>.SetAxisDirection()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetAxisDirection
 [Drive<AngularDriveFacade, AngularDrive>.ProcessDriveSpeed(Single, Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ProcessDriveSpeed_System_Single_System_Boolean_
 [Drive<AngularDriveFacade, AngularDrive>.SetTargetValue(Single)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetTargetValue_System_Single_
 [Drive<AngularDriveFacade, AngularDrive>.CalculateDriveAxis(DriveAxis.Axis)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateDriveAxis_Tilia_Interactions_Controllables_Driver_DriveAxis_Axis_
@@ -577,6 +605,7 @@ IProcessable
 [ActualTargetAngle]: #ActualTargetAngle
 [CurrentActualAngle]: #CurrentActualAngle
 [PreviousActualAngle]: #PreviousActualAngle
+[ResetRotationsOnSetup]: #ResetRotationsOnSetup
 [Methods]: #Methods
 [ApplyExistingAngularVelocity(Single)]: #ApplyExistingAngularVelocitySingle
 [ApplyLimits()]: #ApplyLimits
@@ -591,5 +620,6 @@ IProcessable
 [MatchActualTargetAngle(Single)]: #MatchActualTargetAngleSingle
 [Process()]: #Process
 [ProcessAutoDrive(Single)]: #ProcessAutoDriveSingle
+[ResetRotations()]: #ResetRotations
 [SetUpInternals()]: #SetUpInternals
 [Implements]: #Implements

--- a/Documentation/API/AngularDriver/AngularDriveFacade.md
+++ b/Documentation/API/AngularDriver/AngularDriveFacade.md
@@ -13,8 +13,14 @@ The public interface into any RotationalDrive prefab.
   * [GizmoSphereRadius]
   * [HingeLocation]
 * [Methods]
+  * [OnAfterDriveLimitChange()]
   * [OnAfterHingeLocationChange()]
   * [OnDrawGizmosSelected()]
+  * [SetDriveLimitMaximum(Single)]
+  * [SetDriveLimitMinimum(Single)]
+  * [SetHingeLocationX(Single)]
+  * [SetHingeLocationY(Single)]
+  * [SetHingeLocationZ(Single)]
 
 ## Details
 
@@ -57,6 +63,12 @@ The public interface into any RotationalDrive prefab.
 [DriveFacade<AngularDrive, AngularDriveFacade>.StepRange]
 
 [DriveFacade<AngularDrive, AngularDriveFacade>.StepIncrement]
+
+[DriveFacade<AngularDrive, AngularDriveFacade>.SetDriveAxis(Int32)]
+
+[DriveFacade<AngularDrive, AngularDriveFacade>.SetStepRangeMinimum(Single)]
+
+[DriveFacade<AngularDrive, AngularDriveFacade>.SetStepRangeMaximum(Single)]
 
 [DriveFacade<AngularDrive, AngularDriveFacade>.SetTargetValueByStepValue()]
 
@@ -138,6 +150,16 @@ public Vector3 HingeLocation { get; set; }
 
 ### Methods
 
+#### OnAfterDriveLimitChange()
+
+Called after [DriveLimit] has been changed.
+
+##### Declaration
+
+```
+protected virtual void OnAfterDriveLimitChange()
+```
+
 #### OnAfterHingeLocationChange()
 
 Called after [HingeLocation] has been changed.
@@ -155,6 +177,86 @@ protected virtual void OnAfterHingeLocationChange()
 ```
 protected virtual void OnDrawGizmosSelected()
 ```
+
+#### SetDriveLimitMaximum(Single)
+
+Sets the [DriveLimit] maximum value.
+
+##### Declaration
+
+```
+public virtual void SetDriveLimitMaximum(float value)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | value | The new maximum value. |
+
+#### SetDriveLimitMinimum(Single)
+
+Sets the [DriveLimit] minimum value.
+
+##### Declaration
+
+```
+public virtual void SetDriveLimitMinimum(float value)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | value | The new minimum value. |
+
+#### SetHingeLocationX(Single)
+
+Sets the [HingeLocation] x value.
+
+##### Declaration
+
+```
+public virtual void SetHingeLocationX(float value)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | value | The new x value. |
+
+#### SetHingeLocationY(Single)
+
+Sets the [HingeLocation] y value.
+
+##### Declaration
+
+```
+public virtual void SetHingeLocationY(float value)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | value | The new y value. |
+
+#### SetHingeLocationZ(Single)
+
+Sets the [HingeLocation] z value.
+
+##### Declaration
+
+```
+public virtual void SetHingeLocationZ(float value)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | value | The new z value. |
 
 [DriveFacade]: ../Driver/DriveFacade-2.md
 [AngularDrive]: AngularDrive.md
@@ -175,6 +277,9 @@ protected virtual void OnDrawGizmosSelected()
 [DriveFacade<AngularDrive, AngularDriveFacade>.TargetValue]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_TargetValue
 [DriveFacade<AngularDrive, AngularDriveFacade>.StepRange]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_StepRange
 [DriveFacade<AngularDrive, AngularDriveFacade>.StepIncrement]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_StepIncrement
+[DriveFacade<AngularDrive, AngularDriveFacade>.SetDriveAxis(Int32)]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_SetDriveAxis_System_Int32_
+[DriveFacade<AngularDrive, AngularDriveFacade>.SetStepRangeMinimum(Single)]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_SetStepRangeMinimum_System_Single_
+[DriveFacade<AngularDrive, AngularDriveFacade>.SetStepRangeMaximum(Single)]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_SetStepRangeMaximum_System_Single_
 [DriveFacade<AngularDrive, AngularDriveFacade>.SetTargetValueByStepValue()]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_SetTargetValueByStepValue
 [DriveFacade<AngularDrive, AngularDriveFacade>.SetTargetValueByStepValue(Single)]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_SetTargetValueByStepValue_System_Single_
 [DriveFacade<AngularDrive, AngularDriveFacade>.ForceSnapToStepValue(Single)]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_ForceSnapToStepValue_System_Single_
@@ -189,6 +294,12 @@ protected virtual void OnDrawGizmosSelected()
 [DriveFacade<AngularDrive, AngularDriveFacade>.OnAfterStepRangeChange()]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_OnAfterStepRangeChange
 [DriveFacade<AngularDrive, AngularDriveFacade>.OnAfterStepIncrementChange()]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_OnAfterStepIncrementChange
 [Tilia.Interactions.Controllables.AngularDriver]: README.md
+[DriveLimit]: AngularDriveFacade.md#DriveLimit
+[HingeLocation]: AngularDriveFacade.md#HingeLocation
+[DriveLimit]: AngularDriveFacade.md#DriveLimit
+[DriveLimit]: AngularDriveFacade.md#DriveLimit
+[HingeLocation]: AngularDriveFacade.md#HingeLocation
+[HingeLocation]: AngularDriveFacade.md#HingeLocation
 [HingeLocation]: AngularDriveFacade.md#HingeLocation
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
@@ -199,5 +310,11 @@ protected virtual void OnDrawGizmosSelected()
 [GizmoSphereRadius]: #GizmoSphereRadius
 [HingeLocation]: #HingeLocation
 [Methods]: #Methods
+[OnAfterDriveLimitChange()]: #OnAfterDriveLimitChange
 [OnAfterHingeLocationChange()]: #OnAfterHingeLocationChange
 [OnDrawGizmosSelected()]: #OnDrawGizmosSelected
+[SetDriveLimitMaximum(Single)]: #SetDriveLimitMaximumSingle
+[SetDriveLimitMinimum(Single)]: #SetDriveLimitMinimumSingle
+[SetHingeLocationX(Single)]: #SetHingeLocationXSingle
+[SetHingeLocationY(Single)]: #SetHingeLocationYSingle
+[SetHingeLocationZ(Single)]: #SetHingeLocationZSingle

--- a/Documentation/API/AngularDriver/AngularJointDrive.md
+++ b/Documentation/API/AngularDriver/AngularJointDrive.md
@@ -42,6 +42,8 @@ IProcessable
 
 ##### Inherited Members
 
+[AngularDrive.ResetRotationsOnSetup]
+
 [AngularDrive.PreviousActualAngle]
 
 [AngularDrive.CurrentActualAngle]
@@ -67,6 +69,8 @@ IProcessable
 [AngularDrive.currentActualRotation]
 
 [AngularDrive.Process()]
+
+[AngularDrive.ResetRotations()]
 
 [AngularDrive.CalculateDriveLimits(AngularDriveFacade)]
 
@@ -127,6 +131,10 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.SetUp()]
 
 [Drive<AngularDriveFacade, AngularDrive>.Process()]
+
+[Drive<AngularDriveFacade, AngularDrive>.SetDriveLimits()]
+
+[Drive<AngularDriveFacade, AngularDrive>.SetAxisDirection()]
 
 [Drive<AngularDriveFacade, AngularDrive>.ProcessDriveSpeed(Single, Boolean)]
 
@@ -423,6 +431,7 @@ IProcessable
 [Drive]: ../Driver/Drive-2.md
 [AngularDriveFacade]: AngularDriveFacade.md
 [AngularDrive]: AngularDrive.md
+[AngularDrive.ResetRotationsOnSetup]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_ResetRotationsOnSetup
 [AngularDrive.PreviousActualAngle]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_PreviousActualAngle
 [AngularDrive.CurrentActualAngle]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_CurrentActualAngle
 [AngularDrive.ActualTargetAngle]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_ActualTargetAngle
@@ -436,6 +445,7 @@ IProcessable
 [AngularDrive.previousActualRotation]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_previousActualRotation
 [AngularDrive.currentActualRotation]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_currentActualRotation
 [AngularDrive.Process()]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_Process
+[AngularDrive.ResetRotations()]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_ResetRotations
 [AngularDrive.CalculateDriveLimits(AngularDriveFacade)]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_CalculateDriveLimits_Tilia_Interactions_Controllables_AngularDriver_AngularDriveFacade_
 [AngularDrive.CalculateValue(DriveAxis.Axis, FloatRange)]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_CalculateValue_Tilia_Interactions_Controllables_Driver_DriveAxis_Axis_FloatRange_
 [AngularDrive.GetSimpleEulerAngles()]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_GetSimpleEulerAngles
@@ -466,6 +476,8 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.cachedDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedDriveSpeed
 [Drive<AngularDriveFacade, AngularDrive>.SetUp()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetUp
 [Drive<AngularDriveFacade, AngularDrive>.Process()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Process
+[Drive<AngularDriveFacade, AngularDrive>.SetDriveLimits()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetDriveLimits
+[Drive<AngularDriveFacade, AngularDrive>.SetAxisDirection()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetAxisDirection
 [Drive<AngularDriveFacade, AngularDrive>.ProcessDriveSpeed(Single, Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ProcessDriveSpeed_System_Single_System_Boolean_
 [Drive<AngularDriveFacade, AngularDrive>.SetTargetValue(Single)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetTargetValue_System_Single_
 [Drive<AngularDriveFacade, AngularDrive>.CalculateDriveAxis(DriveAxis.Axis)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateDriveAxis_Tilia_Interactions_Controllables_Driver_DriveAxis_Axis_

--- a/Documentation/API/AngularDriver/AngularTransformDrive.md
+++ b/Documentation/API/AngularDriver/AngularTransformDrive.md
@@ -37,6 +37,8 @@ IProcessable
 
 ##### Inherited Members
 
+[AngularDrive.ResetRotationsOnSetup]
+
 [AngularDrive.PreviousActualAngle]
 
 [AngularDrive.CurrentActualAngle]
@@ -62,6 +64,8 @@ IProcessable
 [AngularDrive.currentActualRotation]
 
 [AngularDrive.Process()]
+
+[AngularDrive.ResetRotations()]
 
 [AngularDrive.SetUpInternals()]
 
@@ -124,6 +128,10 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.SetUp()]
 
 [Drive<AngularDriveFacade, AngularDrive>.Process()]
+
+[Drive<AngularDriveFacade, AngularDrive>.SetDriveLimits()]
+
+[Drive<AngularDriveFacade, AngularDrive>.SetAxisDirection()]
 
 [Drive<AngularDriveFacade, AngularDrive>.ProcessDriveSpeed(Single, Boolean)]
 
@@ -364,6 +372,7 @@ IProcessable
 [Drive]: ../Driver/Drive-2.md
 [AngularDriveFacade]: AngularDriveFacade.md
 [AngularDrive]: AngularDrive.md
+[AngularDrive.ResetRotationsOnSetup]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_ResetRotationsOnSetup
 [AngularDrive.PreviousActualAngle]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_PreviousActualAngle
 [AngularDrive.CurrentActualAngle]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_CurrentActualAngle
 [AngularDrive.ActualTargetAngle]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_ActualTargetAngle
@@ -377,6 +386,7 @@ IProcessable
 [AngularDrive.previousActualRotation]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_previousActualRotation
 [AngularDrive.currentActualRotation]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_currentActualRotation
 [AngularDrive.Process()]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_Process
+[AngularDrive.ResetRotations()]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_ResetRotations
 [AngularDrive.SetUpInternals()]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_SetUpInternals
 [AngularDrive.CalculateDriveLimits(AngularDriveFacade)]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_CalculateDriveLimits_Tilia_Interactions_Controllables_AngularDriver_AngularDriveFacade_
 [AngularDrive.CalculateValue(DriveAxis.Axis, FloatRange)]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_CalculateValue_Tilia_Interactions_Controllables_Driver_DriveAxis_Axis_FloatRange_
@@ -408,6 +418,8 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.cachedDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedDriveSpeed
 [Drive<AngularDriveFacade, AngularDrive>.SetUp()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetUp
 [Drive<AngularDriveFacade, AngularDrive>.Process()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Process
+[Drive<AngularDriveFacade, AngularDrive>.SetDriveLimits()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetDriveLimits
+[Drive<AngularDriveFacade, AngularDrive>.SetAxisDirection()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetAxisDirection
 [Drive<AngularDriveFacade, AngularDrive>.ProcessDriveSpeed(Single, Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ProcessDriveSpeed_System_Single_System_Boolean_
 [Drive<AngularDriveFacade, AngularDrive>.SetTargetValue(Single)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetTargetValue_System_Single_
 [Drive<AngularDriveFacade, AngularDrive>.CalculateDriveAxis(DriveAxis.Axis)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateDriveAxis_Tilia_Interactions_Controllables_Driver_DriveAxis_Axis_

--- a/Documentation/API/Driver/Drive-2.md
+++ b/Documentation/API/Driver/Drive-2.md
@@ -50,6 +50,8 @@ The basis for a mechanism to drive motion on a control.
   * [Process()]
   * [ProcessDriveSpeed(Single, Boolean)]
   * [ResetToCacheAfterReachedInitialTargetValue()]
+  * [SetAxisDirection()]
+  * [SetDriveLimits()]
   * [SetDriveTargetValue(Vector3)]
   * [SetTargetValue(Single)]
   * [SetUp()]
@@ -570,6 +572,26 @@ Resets the drive parameters to the cached values after the initial target value 
 protected virtual void ResetToCacheAfterReachedInitialTargetValue()
 ```
 
+#### SetAxisDirection()
+
+Sets the [AxisDirection] based on the Facade.DriveAxis value.
+
+##### Declaration
+
+```
+public virtual void SetAxisDirection()
+```
+
+#### SetDriveLimits()
+
+Sets the [DriveLimits] based on the [Facade] drive limit settings.
+
+##### Declaration
+
+```
+public virtual void SetDriveLimits()
+```
+
 #### SetDriveTargetValue(Vector3)
 
 Sets the target value of the drive.
@@ -634,6 +656,9 @@ IProcessable
 [StepValue]: Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_StepValue
 [Value]: Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Value
 [DriveAxis.Axis]: DriveAxis.Axis.md
+[AxisDirection]: Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_AxisDirection
+[DriveLimits]: Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_DriveLimits
+[Facade]: Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Facade
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
 [Syntax]: #Syntax
@@ -680,6 +705,8 @@ IProcessable
 [Process()]: #Process
 [ProcessDriveSpeed(Single, Boolean)]: #ProcessDriveSpeedSingle-Boolean
 [ResetToCacheAfterReachedInitialTargetValue()]: #ResetToCacheAfterReachedInitialTargetValue
+[SetAxisDirection()]: #SetAxisDirection
+[SetDriveLimits()]: #SetDriveLimits
 [SetDriveTargetValue(Vector3)]: #SetDriveTargetValueVector3
 [SetTargetValue(Single)]: #SetTargetValueSingle
 [SetUp()]: #SetUp

--- a/Documentation/API/Driver/DriveFacade-2.md
+++ b/Documentation/API/Driver/DriveFacade-2.md
@@ -36,6 +36,9 @@ The basis of the public interface that will drive a control in relation to a spe
   * [OnAfterTargetValueChange()]
   * [ProcessAutoDrive(Boolean)]
   * [ProcessDriveSpeed(Single, Boolean)]
+  * [SetDriveAxis(Int32)]
+  * [SetStepRangeMaximum(Single)]
+  * [SetStepRangeMinimum(Single)]
   * [SetTargetValue(Single)]
   * [SetTargetValueByStepValue()]
   * [SetTargetValueByStepValue(Single)]
@@ -357,6 +360,54 @@ protected virtual void ProcessDriveSpeed(float driveSpeed, bool moveToTargetValu
 | System.Single | driveSpeed | The new value. |
 | System.Boolean | moveToTargetValue | Whether the new value should be processed. |
 
+#### SetDriveAxis(Int32)
+
+Sets [DriveAxis].
+
+##### Declaration
+
+```
+public virtual void SetDriveAxis(int axisIndex)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Int32 | axisIndex | The index of the [DriveAxis.Axis]. |
+
+#### SetStepRangeMaximum(Single)
+
+Sets the [StepRange] maximum value.
+
+##### Declaration
+
+```
+public virtual void SetStepRangeMaximum(float value)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | value | The new maximum value. |
+
+#### SetStepRangeMinimum(Single)
+
+Sets the [StepRange] minimum value.
+
+##### Declaration
+
+```
+public virtual void SetStepRangeMinimum(float value)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | value | The new minimum value. |
+
 #### SetTargetValue(Single)
 
 Sets the new [TargetValue].
@@ -409,7 +460,6 @@ public virtual void SetTargetValueByStepValue(float stepValue)
 [TargetValue]: DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_TargetValue
 [InitialTargetValue]: DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_InitialTargetValue
 [MoveToTargetValue]: DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_MoveToTargetValue
-[DriveAxis.Axis]: DriveAxis.Axis.md
 [DriveAxis]: DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_DriveAxis
 [DriveSpeed]: DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_DriveSpeed
 [MoveToTargetValue]: DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_MoveToTargetValue
@@ -417,6 +467,10 @@ public virtual void SetTargetValueByStepValue(float stepValue)
 [StepRange]: DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_StepRange
 [TargetValue]: DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_TargetValue
 [DriveSpeed]: DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_DriveSpeed
+[DriveAxis]: DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_DriveAxis
+[DriveAxis.Axis]: DriveAxis.Axis.md
+[StepRange]: DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_StepRange
+[StepRange]: DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_StepRange
 [TargetValue]: DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_TargetValue
 [TargetValue]: DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_TargetValue
 [TargetValue]: DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_TargetValue
@@ -452,6 +506,9 @@ public virtual void SetTargetValueByStepValue(float stepValue)
 [OnAfterTargetValueChange()]: #OnAfterTargetValueChange
 [ProcessAutoDrive(Boolean)]: #ProcessAutoDriveBoolean
 [ProcessDriveSpeed(Single, Boolean)]: #ProcessDriveSpeedSingle-Boolean
+[SetDriveAxis(Int32)]: #SetDriveAxisInt32
+[SetStepRangeMaximum(Single)]: #SetStepRangeMaximumSingle
+[SetStepRangeMinimum(Single)]: #SetStepRangeMinimumSingle
 [SetTargetValue(Single)]: #SetTargetValueSingle
 [SetTargetValueByStepValue()]: #SetTargetValueByStepValue
 [SetTargetValueByStepValue(Single)]: #SetTargetValueByStepValueSingle

--- a/Documentation/API/LinearDriver/LinearDrive.md
+++ b/Documentation/API/LinearDriver/LinearDrive.md
@@ -74,6 +74,10 @@ IProcessable
 
 [Drive<LinearDriveFacade, LinearDrive>.Process()]
 
+[Drive<LinearDriveFacade, LinearDrive>.SetDriveLimits()]
+
+[Drive<LinearDriveFacade, LinearDrive>.SetAxisDirection()]
+
 [Drive<LinearDriveFacade, LinearDrive>.ProcessDriveSpeed(Single, Boolean)]
 
 [Drive<LinearDriveFacade, LinearDrive>.SetTargetValue(Single)]
@@ -255,6 +259,8 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.cachedDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedDriveSpeed
 [Drive<LinearDriveFacade, LinearDrive>.SetUp()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetUp
 [Drive<LinearDriveFacade, LinearDrive>.Process()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Process
+[Drive<LinearDriveFacade, LinearDrive>.SetDriveLimits()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetDriveLimits
+[Drive<LinearDriveFacade, LinearDrive>.SetAxisDirection()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetAxisDirection
 [Drive<LinearDriveFacade, LinearDrive>.ProcessDriveSpeed(Single, Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ProcessDriveSpeed_System_Single_System_Boolean_
 [Drive<LinearDriveFacade, LinearDrive>.SetTargetValue(Single)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetTargetValue_System_Single_
 [Drive<LinearDriveFacade, LinearDrive>.CalculateDriveAxis(DriveAxis.Axis)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateDriveAxis_Tilia_Interactions_Controllables_Driver_DriveAxis_Axis_

--- a/Documentation/API/LinearDriver/LinearDriveFacade.md
+++ b/Documentation/API/LinearDriver/LinearDriveFacade.md
@@ -56,6 +56,12 @@ The public interface into any Linear Drive prefab.
 
 [DriveFacade<LinearDrive, LinearDriveFacade>.StepIncrement]
 
+[DriveFacade<LinearDrive, LinearDriveFacade>.SetDriveAxis(Int32)]
+
+[DriveFacade<LinearDrive, LinearDriveFacade>.SetStepRangeMinimum(Single)]
+
+[DriveFacade<LinearDrive, LinearDriveFacade>.SetStepRangeMaximum(Single)]
+
 [DriveFacade<LinearDrive, LinearDriveFacade>.SetTargetValueByStepValue()]
 
 [DriveFacade<LinearDrive, LinearDriveFacade>.SetTargetValueByStepValue(Single)]
@@ -153,6 +159,9 @@ protected virtual void OnDrawGizmosSelected()
 [DriveFacade<LinearDrive, LinearDriveFacade>.TargetValue]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_TargetValue
 [DriveFacade<LinearDrive, LinearDriveFacade>.StepRange]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_StepRange
 [DriveFacade<LinearDrive, LinearDriveFacade>.StepIncrement]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_StepIncrement
+[DriveFacade<LinearDrive, LinearDriveFacade>.SetDriveAxis(Int32)]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_SetDriveAxis_System_Int32_
+[DriveFacade<LinearDrive, LinearDriveFacade>.SetStepRangeMinimum(Single)]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_SetStepRangeMinimum_System_Single_
+[DriveFacade<LinearDrive, LinearDriveFacade>.SetStepRangeMaximum(Single)]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_SetStepRangeMaximum_System_Single_
 [DriveFacade<LinearDrive, LinearDriveFacade>.SetTargetValueByStepValue()]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_SetTargetValueByStepValue
 [DriveFacade<LinearDrive, LinearDriveFacade>.SetTargetValueByStepValue(Single)]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_SetTargetValueByStepValue_System_Single_
 [DriveFacade<LinearDrive, LinearDriveFacade>.ForceSnapToStepValue(Single)]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_ForceSnapToStepValue_System_Single_

--- a/Documentation/API/LinearDriver/LinearJointDrive.md
+++ b/Documentation/API/LinearDriver/LinearJointDrive.md
@@ -86,6 +86,10 @@ IProcessable
 
 [Drive<LinearDriveFacade, LinearDrive>.Process()]
 
+[Drive<LinearDriveFacade, LinearDrive>.SetDriveLimits()]
+
+[Drive<LinearDriveFacade, LinearDrive>.SetAxisDirection()]
+
 [Drive<LinearDriveFacade, LinearDrive>.ProcessDriveSpeed(Single, Boolean)]
 
 [Drive<LinearDriveFacade, LinearDrive>.SetTargetValue(Single)]
@@ -339,6 +343,8 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.cachedDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedDriveSpeed
 [Drive<LinearDriveFacade, LinearDrive>.SetUp()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetUp
 [Drive<LinearDriveFacade, LinearDrive>.Process()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Process
+[Drive<LinearDriveFacade, LinearDrive>.SetDriveLimits()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetDriveLimits
+[Drive<LinearDriveFacade, LinearDrive>.SetAxisDirection()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetAxisDirection
 [Drive<LinearDriveFacade, LinearDrive>.ProcessDriveSpeed(Single, Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ProcessDriveSpeed_System_Single_System_Boolean_
 [Drive<LinearDriveFacade, LinearDrive>.SetTargetValue(Single)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetTargetValue_System_Single_
 [Drive<LinearDriveFacade, LinearDrive>.CalculateDriveAxis(DriveAxis.Axis)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateDriveAxis_Tilia_Interactions_Controllables_Driver_DriveAxis_Axis_

--- a/Documentation/API/LinearDriver/LinearTransformDrive.md
+++ b/Documentation/API/LinearDriver/LinearTransformDrive.md
@@ -86,6 +86,10 @@ IProcessable
 
 [Drive<LinearDriveFacade, LinearDrive>.Process()]
 
+[Drive<LinearDriveFacade, LinearDrive>.SetDriveLimits()]
+
+[Drive<LinearDriveFacade, LinearDrive>.SetAxisDirection()]
+
 [Drive<LinearDriveFacade, LinearDrive>.ProcessDriveSpeed(Single, Boolean)]
 
 [Drive<LinearDriveFacade, LinearDrive>.SetTargetValue(Single)]
@@ -308,6 +312,8 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.cachedDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedDriveSpeed
 [Drive<LinearDriveFacade, LinearDrive>.SetUp()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetUp
 [Drive<LinearDriveFacade, LinearDrive>.Process()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Process
+[Drive<LinearDriveFacade, LinearDrive>.SetDriveLimits()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetDriveLimits
+[Drive<LinearDriveFacade, LinearDrive>.SetAxisDirection()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetAxisDirection
 [Drive<LinearDriveFacade, LinearDrive>.ProcessDriveSpeed(Single, Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ProcessDriveSpeed_System_Single_System_Boolean_
 [Drive<LinearDriveFacade, LinearDrive>.SetTargetValue(Single)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetTargetValue_System_Single_
 [Drive<LinearDriveFacade, LinearDrive>.CalculateDriveAxis(DriveAxis.Axis)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateDriveAxis_Tilia_Interactions_Controllables_Driver_DriveAxis_Axis_

--- a/Runtime/Prefabs/PhysicsJoint/Interactions.AngularJointDrive.prefab
+++ b/Runtime/Prefabs/PhysicsJoint/Interactions.AngularJointDrive.prefab
@@ -49,6 +49,8 @@ MonoBehaviour:
   facade: {fileID: 7220336169150892439}
   eventOutputContainer: {fileID: 6704188405665079684}
   targetValueReachedThreshold: 0.075
+  emitEvents: 1
+  resetRotationsOnSetup: 1
   joint: {fileID: 1471341665110845562}
   jointContainer: {fileID: 5306551537282979864}
 --- !u!114 &8646993169910720069
@@ -258,6 +260,11 @@ MonoBehaviour:
         m_CallState: 2
     m_TypeName: Tilia.Interactions.Controllables.Driver.DriveUnityEvent, Tilia.Interactions.Controllables.Unity.Runtime,
       Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  InitialTargetValueReached:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Tilia.Interactions.Controllables.Driver.DriveUnityEvent, Tilia.Interactions.Controllables.Unity.Runtime,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   TargetValueReached:
     m_PersistentCalls:
       m_Calls: []
@@ -274,9 +281,11 @@ MonoBehaviour:
     m_TypeName: Tilia.Interactions.Controllables.Driver.DriveUnityEvent, Tilia.Interactions.Controllables.Unity.Runtime,
       Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   driveAxis: 0
+  driveSpeed: 10
+  startAtInitialTargetValue: 0
+  initialTargetValue: 0.5
   moveToTargetValue: 0
   targetValue: 0.5
-  driveSpeed: 10
   stepRange:
     minimum: 0
     maximum: 10
@@ -479,26 +488,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: Interactable.GrabAction.Follow
       objectReference: {fileID: 0}
-    - target: {fileID: 3607323991379943426, guid: 702caa48c730e92469a1c5144fd8ed46,
-        type: 3}
-      propertyPath: grabOffset
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 3607323991379943426, guid: 702caa48c730e92469a1c5144fd8ed46,
-        type: 3}
-      propertyPath: followTracking
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 3607323991379943426, guid: 702caa48c730e92469a1c5144fd8ed46,
-        type: 3}
-      propertyPath: isKinematicWhenActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3607323991379943426, guid: 702caa48c730e92469a1c5144fd8ed46,
-        type: 3}
-      propertyPath: willInheritIsKinematicWhenInactiveFromConsumerRigidbody
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 2857845961663347754, guid: 702caa48c730e92469a1c5144fd8ed46,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -552,6 +541,26 @@ PrefabInstance:
     - target: {fileID: 2857845961663347754, guid: 702caa48c730e92469a1c5144fd8ed46,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3607323991379943426, guid: 702caa48c730e92469a1c5144fd8ed46,
+        type: 3}
+      propertyPath: grabOffset
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3607323991379943426, guid: 702caa48c730e92469a1c5144fd8ed46,
+        type: 3}
+      propertyPath: followTracking
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3607323991379943426, guid: 702caa48c730e92469a1c5144fd8ed46,
+        type: 3}
+      propertyPath: isKinematicWhenActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3607323991379943426, guid: 702caa48c730e92469a1c5144fd8ed46,
+        type: 3}
+      propertyPath: willInheritIsKinematicWhenInactiveFromConsumerRigidbody
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4297763714491022842, guid: 702caa48c730e92469a1c5144fd8ed46,
@@ -737,6 +746,71 @@ PrefabInstance:
       propertyPath: m_Name
       value: Interactions.Interactable
       objectReference: {fileID: 0}
+    - target: {fileID: 8090891674275893548, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8090891674275893548, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8090891674275893548, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8090891674275893548, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8090891674275893548, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8090891674275893548, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8090891674275893548, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8090891674275893548, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8090891674275893548, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8090891674275893548, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8090891674275893548, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3648960081298957348, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
+        type: 3}
+      propertyPath: primaryAction
+      value: 
+      objectReference: {fileID: 4070728723303430929}
+    - target: {fileID: 3648960081298957348, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
+        type: 3}
+      propertyPath: secondaryAction
+      value: 
+      objectReference: {fileID: 7610232722202251261}
     - target: {fileID: 785982709505707726, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
         type: 3}
       propertyPath: FirstGrabbed.m_PersistentCalls.m_Calls.Array.size
@@ -807,71 +881,6 @@ PrefabInstance:
       propertyPath: LastUngrabbed.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_FloatArgument
       value: 0.01
       objectReference: {fileID: 0}
-    - target: {fileID: 8090891674275893548, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8090891674275893548, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8090891674275893548, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8090891674275893548, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8090891674275893548, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8090891674275893548, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8090891674275893548, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8090891674275893548, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8090891674275893548, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8090891674275893548, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8090891674275893548, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 3648960081298957348, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
-        type: 3}
-      propertyPath: primaryAction
-      value: 
-      objectReference: {fileID: 4070728723303430929}
-    - target: {fileID: 3648960081298957348, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
-        type: 3}
-      propertyPath: secondaryAction
-      value: 
-      objectReference: {fileID: 7610232722202251261}
     - target: {fileID: 6666400304308521552, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
         type: 3}
       propertyPath: consumerContainer

--- a/Runtime/Prefabs/PhysicsJoint/Interactions.LinearJointDrive.prefab
+++ b/Runtime/Prefabs/PhysicsJoint/Interactions.LinearJointDrive.prefab
@@ -299,6 +299,11 @@ MonoBehaviour:
         m_CallState: 2
     m_TypeName: Tilia.Interactions.Controllables.Driver.DriveUnityEvent, Tilia.Interactions.Controllables.Unity.Runtime,
       Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  InitialTargetValueReached:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Tilia.Interactions.Controllables.Driver.DriveUnityEvent, Tilia.Interactions.Controllables.Unity.Runtime,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   TargetValueReached:
     m_PersistentCalls:
       m_Calls: []
@@ -315,9 +320,11 @@ MonoBehaviour:
     m_TypeName: Tilia.Interactions.Controllables.Driver.DriveUnityEvent, Tilia.Interactions.Controllables.Unity.Runtime,
       Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   driveAxis: 0
+  driveSpeed: 10
+  startAtInitialTargetValue: 0
+  initialTargetValue: 0.5
   moveToTargetValue: 0
   targetValue: 0.5
-  driveSpeed: 10
   stepRange:
     minimum: 0
     maximum: 10
@@ -459,6 +466,7 @@ MonoBehaviour:
   facade: {fileID: 2321230931700777055}
   eventOutputContainer: {fileID: 7344147712558315100}
   targetValueReachedThreshold: 0.025
+  emitEvents: 1
   joint: {fileID: 2051297999214337113}
 --- !u!114 &1069736518602212927
 MonoBehaviour:
@@ -651,21 +659,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: Interactable.GrabAction.Follow
       objectReference: {fileID: 0}
-    - target: {fileID: 3607323991379943426, guid: 702caa48c730e92469a1c5144fd8ed46,
-        type: 3}
-      propertyPath: followTracking
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 3607323991379943426, guid: 702caa48c730e92469a1c5144fd8ed46,
-        type: 3}
-      propertyPath: grabOffset
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 3607323991379943426, guid: 702caa48c730e92469a1c5144fd8ed46,
-        type: 3}
-      propertyPath: isKinematicWhenActive
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 2857845961663347754, guid: 702caa48c730e92469a1c5144fd8ed46,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -719,6 +712,21 @@ PrefabInstance:
     - target: {fileID: 2857845961663347754, guid: 702caa48c730e92469a1c5144fd8ed46,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3607323991379943426, guid: 702caa48c730e92469a1c5144fd8ed46,
+        type: 3}
+      propertyPath: followTracking
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3607323991379943426, guid: 702caa48c730e92469a1c5144fd8ed46,
+        type: 3}
+      propertyPath: grabOffset
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3607323991379943426, guid: 702caa48c730e92469a1c5144fd8ed46,
+        type: 3}
+      propertyPath: isKinematicWhenActive
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []

--- a/Runtime/Prefabs/Transform/Interactions.AngularTransformDrive.prefab
+++ b/Runtime/Prefabs/Transform/Interactions.AngularTransformDrive.prefab
@@ -94,6 +94,11 @@ MonoBehaviour:
         m_CallState: 2
     m_TypeName: Tilia.Interactions.Controllables.Driver.DriveUnityEvent, Tilia.Interactions.Controllables.Unity.Runtime,
       Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  InitialTargetValueReached:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Tilia.Interactions.Controllables.Driver.DriveUnityEvent, Tilia.Interactions.Controllables.Unity.Runtime,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   TargetValueReached:
     m_PersistentCalls:
       m_Calls: []
@@ -110,9 +115,11 @@ MonoBehaviour:
     m_TypeName: Tilia.Interactions.Controllables.Driver.DriveUnityEvent, Tilia.Interactions.Controllables.Unity.Runtime,
       Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   driveAxis: 0
+  driveSpeed: 10
+  startAtInitialTargetValue: 0
+  initialTargetValue: 0.5
   moveToTargetValue: 0
   targetValue: 0.5
-  driveSpeed: 10
   stepRange:
     minimum: 0
     maximum: 10
@@ -172,6 +179,8 @@ MonoBehaviour:
   facade: {fileID: 2116566820272827043}
   eventOutputContainer: {fileID: 6134235524921124102}
   targetValueReachedThreshold: 0.075
+  emitEvents: 1
+  resetRotationsOnSetup: 1
   interactable: {fileID: 4763570561051037854}
   interactableMesh: {fileID: 6582222421973241952}
   rotationModifier: {fileID: 9194919288075826165}
@@ -386,21 +395,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: Interactable.GrabAction.Follow
       objectReference: {fileID: 0}
-    - target: {fileID: 3607323991379943426, guid: 702caa48c730e92469a1c5144fd8ed46,
-        type: 3}
-      propertyPath: followTracking
-      value: 3
-      objectReference: {fileID: 0}
-    - target: {fileID: 3607323991379943426, guid: 702caa48c730e92469a1c5144fd8ed46,
-        type: 3}
-      propertyPath: grabOffset
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 3607323991379943426, guid: 702caa48c730e92469a1c5144fd8ed46,
-        type: 3}
-      propertyPath: isKinematicWhenInactive
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 2857845961663347754, guid: 702caa48c730e92469a1c5144fd8ed46,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -455,6 +449,21 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3607323991379943426, guid: 702caa48c730e92469a1c5144fd8ed46,
+        type: 3}
+      propertyPath: followTracking
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 3607323991379943426, guid: 702caa48c730e92469a1c5144fd8ed46,
+        type: 3}
+      propertyPath: grabOffset
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3607323991379943426, guid: 702caa48c730e92469a1c5144fd8ed46,
+        type: 3}
+      propertyPath: isKinematicWhenInactive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 7813340367162748559, guid: 702caa48c730e92469a1c5144fd8ed46,
         type: 3}

--- a/Runtime/Prefabs/Transform/Interactions.LinearTransformDrive.prefab
+++ b/Runtime/Prefabs/Transform/Interactions.LinearTransformDrive.prefab
@@ -94,6 +94,11 @@ MonoBehaviour:
         m_CallState: 2
     m_TypeName: Tilia.Interactions.Controllables.Driver.DriveUnityEvent, Tilia.Interactions.Controllables.Unity.Runtime,
       Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  InitialTargetValueReached:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Tilia.Interactions.Controllables.Driver.DriveUnityEvent, Tilia.Interactions.Controllables.Unity.Runtime,
+      Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   TargetValueReached:
     m_PersistentCalls:
       m_Calls: []
@@ -110,9 +115,11 @@ MonoBehaviour:
     m_TypeName: Tilia.Interactions.Controllables.Driver.DriveUnityEvent, Tilia.Interactions.Controllables.Unity.Runtime,
       Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
   driveAxis: 0
+  driveSpeed: 10
+  startAtInitialTargetValue: 0
+  initialTargetValue: 0.5
   moveToTargetValue: 0
   targetValue: 0.5
-  driveSpeed: 10
   stepRange:
     minimum: 0
     maximum: 10
@@ -295,6 +302,7 @@ MonoBehaviour:
     zState: 0
   applyTransformations: 1
   transitionDuration: 0
+  shouldApplyToEqualProperties: 0
   transitionDestinationThreshold: 0.01
   isTransitionDestinationDynamic: 0
   BeforeTransformUpdated:
@@ -351,8 +359,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 25c79c0a1b4e65e41beb97b9f66a29fb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  source: {fileID: 743822601413769979}
-  useLocal: 1
   Extracted:
     m_PersistentCalls:
       m_Calls:
@@ -369,6 +375,13 @@ MonoBehaviour:
         m_CallState: 2
     m_TypeName: Zinnia.Data.Operation.Extraction.TransformVector3PropertyExtractor+UnityEvent,
       Zinnia.Runtime, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+  Failed:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine.CoreModule, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  source: {fileID: 743822601413769979}
+  useLocal: 1
 --- !u!114 &7040976075969279408
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -566,6 +579,10 @@ MonoBehaviour:
     yState: 1
     zState: 1
   facingDirection: {fileID: 0}
+  applyFacingDirectionOnAxis:
+    xState: 1
+    yState: 1
+    zState: 1
 --- !u!1 &7040976076263384066
 GameObject:
   m_ObjectHideFlags: 0
@@ -681,6 +698,7 @@ MonoBehaviour:
   facade: {fileID: 7040976075344879994}
   eventOutputContainer: {fileID: 7468202290724158542}
   targetValueReachedThreshold: 0.025
+  emitEvents: 1
   interactable: {fileID: 7736847107121358400}
   positionClamper: {fileID: 7040976076037122787}
   propertyApplier: {fileID: 7040976075776713638}
@@ -1036,16 +1054,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: Interactable.GrabAction.Follow
       objectReference: {fileID: 0}
-    - target: {fileID: 3607323991379943426, guid: 702caa48c730e92469a1c5144fd8ed46,
-        type: 3}
-      propertyPath: grabOffset
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 3607323991379943426, guid: 702caa48c730e92469a1c5144fd8ed46,
-        type: 3}
-      propertyPath: isKinematicWhenInactive
-      value: 1
-      objectReference: {fileID: 0}
     - target: {fileID: 2857845961663347754, guid: 702caa48c730e92469a1c5144fd8ed46,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -1100,6 +1108,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3607323991379943426, guid: 702caa48c730e92469a1c5144fd8ed46,
+        type: 3}
+      propertyPath: grabOffset
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3607323991379943426, guid: 702caa48c730e92469a1c5144fd8ed46,
+        type: 3}
+      propertyPath: isKinematicWhenInactive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 3860205902975461033, guid: 702caa48c730e92469a1c5144fd8ed46,
         type: 3}

--- a/Runtime/SharedResources/Scripts/AngularDriver/AngularDrive.cs
+++ b/Runtime/SharedResources/Scripts/AngularDriver/AngularDrive.cs
@@ -1,6 +1,8 @@
 ﻿namespace Tilia.Interactions.Controllables.AngularDriver
 {
     using Malimbe.BehaviourStateRequirementMethod;
+    using Malimbe.PropertySerializationAttribute;
+    using Malimbe.XmlDocumentationAttribute;
     using Tilia.Interactions.Controllables.Driver;
     using UnityEngine;
     using Zinnia.Data.Type;
@@ -11,6 +13,15 @@
     /// </summary>
     public abstract class AngularDrive : Drive<AngularDriveFacade, AngularDrive>
     {
+        #region Rotation Settings
+        /// <summary>
+        /// The joint being used to drive the rotation.
+        /// </summary>
+        [Serialized]
+        [field: Header("Rotation Settings"), DocumentedByXml]
+        public bool ResetRotationsOnSetup { get; set; } = true;
+        #endregion
+
         /// <summary>
         /// The previous rotation angle of the control.
         /// </summary>
@@ -96,6 +107,17 @@
         }
 
         /// <summary>
+        /// Resets the <see cref="Transform"/> rotation data.
+        /// </summary>
+        public virtual void ResetRotations()
+        {
+            GetDriveTransform().localRotation = Quaternion.identity;
+            previousPseudoRotation = 0f;
+            currentPseudoRotation = 0f;
+            pseudoAngularVelocity = 0f;
+        }
+
+        /// <summary>
         /// Automatically controls the drive to the target rotation at the given speed.
         /// </summary>
         /// <param name="driveSpeed">The speed to automatically rotate the drive.</param>
@@ -104,6 +126,10 @@
         /// <inheritdoc />
         protected override void SetUpInternals()
         {
+            if (ResetRotationsOnSetup)
+            {
+                ResetRotations();
+            }
             ConfigureAutoDrive(Facade.MoveToTargetValue);
             CalculateHingeLocation(Facade.HingeLocation);
         }

--- a/Runtime/SharedResources/Scripts/AngularDriver/AngularDriveFacade.cs
+++ b/Runtime/SharedResources/Scripts/AngularDriver/AngularDriveFacade.cs
@@ -46,6 +46,55 @@
         public float GizmoSphereRadius { get; set; } = 0.015f;
         #endregion
 
+        /// <summary>
+        /// Sets the <see cref="DriveLimit"/> minimum value.
+        /// </summary>
+        /// <param name="value">The new minimum value.</param>
+        public virtual void SetDriveLimitMinimum(float value)
+        {
+            FloatRange newLimit = new FloatRange(DriveLimit.ToVector2());
+            newLimit.minimum = value;
+            DriveLimit = newLimit;
+        }
+
+        /// <summary>
+        /// Sets the <see cref="DriveLimit"/> maximum value.
+        /// </summary>
+        /// <param name="value">The new maximum value.</param>
+        public virtual void SetDriveLimitMaximum(float value)
+        {
+            FloatRange newLimit = new FloatRange(DriveLimit.ToVector2());
+            newLimit.maximum = value;
+            DriveLimit = newLimit;
+        }
+
+        /// <summary>
+        /// Sets the <see cref="HingeLocation"/> x value.
+        /// </summary>
+        /// <param name="value">The new x value.</param>
+        public virtual void SetHingeLocationX(float value)
+        {
+            HingeLocation = new Vector3(value, HingeLocation.y, HingeLocation.z);
+        }
+
+        /// <summary>
+        /// Sets the <see cref="HingeLocation"/> y value.
+        /// </summary>
+        /// <param name="value">The new y value.</param>
+        public virtual void SetHingeLocationY(float value)
+        {
+            HingeLocation = new Vector3(HingeLocation.x, value, HingeLocation.z);
+        }
+
+        /// <summary>
+        /// Sets the <see cref="HingeLocation"/> z value.
+        /// </summary>
+        /// <param name="value">The new z value.</param>
+        public virtual void SetHingeLocationZ(float value)
+        {
+            HingeLocation = new Vector3(HingeLocation.x, HingeLocation.y, value);
+        }
+
         protected virtual void OnDrawGizmosSelected()
         {
             Gizmos.color = Color.yellow;
@@ -57,6 +106,15 @@
             Gizmos.DrawLine(from, to);
             Gizmos.DrawSphere(from, GizmoSphereRadius);
             Gizmos.DrawSphere(to, GizmoSphereRadius);
+        }
+
+        /// <summary>
+        /// Called after <see cref="DriveLimit"/> has been changed.
+        /// </summary>
+        [CalledAfterChangeOf(nameof(DriveLimit))]
+        protected virtual void OnAfterDriveLimitChange()
+        {
+            Drive.SetDriveLimits();
         }
 
         /// <summary>

--- a/Runtime/SharedResources/Scripts/Driver/Drive.cs
+++ b/Runtime/SharedResources/Scripts/Driver/Drive.cs
@@ -115,16 +115,12 @@
         /// <summary>
         /// Sets up the drive mechanism.
         /// </summary>
+        [RequiresBehaviourState]
         public virtual void SetUp()
         {
-            if (!Application.isPlaying)
-            {
-                return;
-            }
-
             SetUpInternals();
-            DriveLimits = CalculateDriveLimits(Facade);
-            AxisDirection = CalculateDriveAxis(Facade.DriveAxis);
+            SetDriveLimits();
+            SetAxisDirection();
             ProcessDriveSpeed(Facade.DriveSpeed, Facade.MoveToTargetValue);
             SetTargetValue(Facade.TargetValue);
         }
@@ -173,10 +169,29 @@
         }
 
         /// <summary>
+        /// Sets the <see cref="DriveLimits"/> based on the <see cref="Facade"/> drive limit settings.
+        /// </summary>
+        [RequiresBehaviourState]
+        public virtual void SetDriveLimits()
+        {
+            DriveLimits = CalculateDriveLimits(Facade);
+        }
+
+        /// <summary>
+        /// Sets the <see cref="AxisDirection"/> based on the <see cref="Facade.DriveAxis"/> value.
+        /// </summary>
+        [RequiresBehaviourState]
+        public virtual void SetAxisDirection()
+        {
+            AxisDirection = CalculateDriveAxis(Facade.DriveAxis);
+        }
+
+        /// <summary>
         /// Processes the speed in which the drive can affect the control.
         /// </summary>
         /// <param name="driveSpeed">The speed to drive the control at.</param>
         /// <param name="moveToTargetValue">Whether to allow the drive to automatically move the control to the desired target value.</param>
+        [RequiresBehaviourState]
         public virtual void ProcessDriveSpeed(float driveSpeed, bool moveToTargetValue) { }
 
         /// <summary>

--- a/Runtime/SharedResources/Scripts/Driver/DriveFacade.cs
+++ b/Runtime/SharedResources/Scripts/Driver/DriveFacade.cs
@@ -129,6 +129,37 @@
         #endregion
 
         /// <summary>
+        /// Sets <see cref="DriveAxis"/>.
+        /// </summary>
+        /// <param name="axisIndex">The index of the <see cref="DriveAxis.Axis"/>.</param>
+        public virtual void SetDriveAxis(int axisIndex)
+        {
+            DriveAxis = (DriveAxis.Axis)Mathf.Clamp(axisIndex, 0, Enum.GetValues(typeof(DriveAxis.Axis)).Length);
+        }
+
+        /// <summary>
+        /// Sets the <see cref="StepRange"/> minimum value.
+        /// </summary>
+        /// <param name="value">The new minimum value.</param>
+        public virtual void SetStepRangeMinimum(float value)
+        {
+            FloatRange newLimit = new FloatRange(StepRange.ToVector2());
+            newLimit.minimum = value;
+            StepRange = newLimit;
+        }
+
+        /// <summary>
+        /// Sets the <see cref="StepRange"/> maximum value.
+        /// </summary>
+        /// <param name="value">The new maximum value.</param>
+        public virtual void SetStepRangeMaximum(float value)
+        {
+            FloatRange newLimit = new FloatRange(StepRange.ToVector2());
+            newLimit.maximum = value;
+            StepRange = newLimit;
+        }
+
+        /// <summary>
         /// Sets the <see cref="TargetValue"/> to the position that the current step value represents.
         /// </summary>
         public virtual void SetTargetValueByStepValue()


### PR DESCRIPTION
A number of properties cannot be changed via UnityEvents because
they are non-standard data types, so methods have been added that
allow for these data types to be changed.

A small fix for the DriveLimits not being updated has been added
and the Setup code has been refactored so the individual setup
elements can now be run individually if need be.

Also, now when the DriveAxis is changed, it will reset the rotation
on the axis as otherwise the rotations cause adverse effects. It
needs looking into further in the future to see if the rotational
data can be kept when switching axes as this would be a nice feature.