### PR TITLE
fix(Drive): rework the drive reset functionality

### DIFF
--- a/Documentation/API/AngularDriver/AngularDrive.md
+++ b/Documentation/API/AngularDriver/AngularDrive.md
@@ -21,7 +21,6 @@ The basis to drive a control in a rotational angle.
   * [ActualTargetAngle]
   * [CurrentActualAngle]
   * [PreviousActualAngle]
-  * [ResetRotationsOnSetup]
 * [Methods]
   * [ApplyExistingAngularVelocity(Single)]
   * [ApplyLimits()]
@@ -36,7 +35,7 @@ The basis to drive a control in a rotational angle.
   * [MatchActualTargetAngle(Single)]
   * [Process()]
   * [ProcessAutoDrive(Single)]
-  * [ResetRotations()]
+  * [ResetDrive()]
   * [SetUpInternals()]
 * [Implements]
 
@@ -59,6 +58,10 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.Facade]
 
 [Drive<AngularDriveFacade, AngularDrive>.EventOutputContainer]
+
+[Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetup]
+
+[Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetupFirstTimeOnly]
 
 [Drive<AngularDriveFacade, AngularDrive>.TargetValueReachedThreshold]
 
@@ -96,6 +99,8 @@ IProcessable
 
 [Drive<AngularDriveFacade, AngularDrive>.cachedDriveSpeed]
 
+[Drive<AngularDriveFacade, AngularDrive>.ConfigureAutoDrive(Boolean)]
+
 [Drive<AngularDriveFacade, AngularDrive>.SetUp()]
 
 [Drive<AngularDriveFacade, AngularDrive>.Process()]
@@ -110,7 +115,7 @@ IProcessable
 
 [Drive<AngularDriveFacade, AngularDrive>.CalculateDriveAxis(DriveAxis.Axis)]
 
-[Drive<AngularDriveFacade, AngularDrive>.ConfigureAutoDrive(Boolean)]
+[Drive<AngularDriveFacade, AngularDrive>.ResetDrive()]
 
 [Drive<AngularDriveFacade, AngularDrive>.CalculateValue(DriveAxis.Axis, FloatRange)]
 
@@ -278,16 +283,6 @@ The previous rotation angle of the control.
 
 ```
 protected float PreviousActualAngle { get; }
-```
-
-#### ResetRotationsOnSetup
-
-The joint being used to drive the rotation.
-
-##### Declaration
-
-```
-public bool ResetRotationsOnSetup { get; set; }
 ```
 
 ### Methods
@@ -507,15 +502,19 @@ protected abstract void ProcessAutoDrive(float driveSpeed)
 | --- | --- | --- |
 | System.Single | driveSpeed | The speed to automatically rotate the drive. |
 
-#### ResetRotations()
+#### ResetDrive()
 
-Resets the Transform rotation data.
+Resets the drive back to any default settings.
 
 ##### Declaration
 
 ```
-public virtual void ResetRotations()
+public override void ResetDrive()
 ```
+
+##### Overrides
+
+Tilia.Interactions.Controllables.Driver.Drive<Tilia.Interactions.Controllables.AngularDriver.AngularDriveFacade, Tilia.Interactions.Controllables.AngularDriver.AngularDrive>.ResetDrive()
 
 #### SetUpInternals()
 
@@ -541,6 +540,8 @@ IProcessable
 [AngularTransformDrive]: AngularTransformDrive.md
 [Drive<AngularDriveFacade, AngularDrive>.Facade]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Facade
 [Drive<AngularDriveFacade, AngularDrive>.EventOutputContainer]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EventOutputContainer
+[Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetup]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetup
+[Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetupFirstTimeOnly]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetupFirstTimeOnly
 [Drive<AngularDriveFacade, AngularDrive>.TargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_TargetValueReachedThreshold
 [Drive<AngularDriveFacade, AngularDrive>.EmitEvents]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitEvents
 [Drive<AngularDriveFacade, AngularDrive>.Value]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Value
@@ -559,6 +560,7 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.cachedMoveToTargetValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedMoveToTargetValue
 [Drive<AngularDriveFacade, AngularDrive>.cachedTargetValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedTargetValue
 [Drive<AngularDriveFacade, AngularDrive>.cachedDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedDriveSpeed
+[Drive<AngularDriveFacade, AngularDrive>.ConfigureAutoDrive(Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ConfigureAutoDrive_System_Boolean_
 [Drive<AngularDriveFacade, AngularDrive>.SetUp()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetUp
 [Drive<AngularDriveFacade, AngularDrive>.Process()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Process
 [Drive<AngularDriveFacade, AngularDrive>.SetDriveLimits()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetDriveLimits
@@ -566,7 +568,7 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.ProcessDriveSpeed(Single, Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ProcessDriveSpeed_System_Single_System_Boolean_
 [Drive<AngularDriveFacade, AngularDrive>.SetTargetValue(Single)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetTargetValue_System_Single_
 [Drive<AngularDriveFacade, AngularDrive>.CalculateDriveAxis(DriveAxis.Axis)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateDriveAxis_Tilia_Interactions_Controllables_Driver_DriveAxis_Axis_
-[Drive<AngularDriveFacade, AngularDrive>.ConfigureAutoDrive(Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ConfigureAutoDrive_System_Boolean_
+[Drive<AngularDriveFacade, AngularDrive>.ResetDrive()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDrive
 [Drive<AngularDriveFacade, AngularDrive>.CalculateValue(DriveAxis.Axis, FloatRange)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateValue_Tilia_Interactions_Controllables_Driver_DriveAxis_Axis_FloatRange_
 [Drive<AngularDriveFacade, AngularDrive>.CalculateDriveLimits(AngularDriveFacade)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateDriveLimits__0_
 [Drive<AngularDriveFacade, AngularDrive>.GetDriveTransform()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GetDriveTransform
@@ -605,7 +607,6 @@ IProcessable
 [ActualTargetAngle]: #ActualTargetAngle
 [CurrentActualAngle]: #CurrentActualAngle
 [PreviousActualAngle]: #PreviousActualAngle
-[ResetRotationsOnSetup]: #ResetRotationsOnSetup
 [Methods]: #Methods
 [ApplyExistingAngularVelocity(Single)]: #ApplyExistingAngularVelocitySingle
 [ApplyLimits()]: #ApplyLimits
@@ -620,6 +621,6 @@ IProcessable
 [MatchActualTargetAngle(Single)]: #MatchActualTargetAngleSingle
 [Process()]: #Process
 [ProcessAutoDrive(Single)]: #ProcessAutoDriveSingle
-[ResetRotations()]: #ResetRotations
+[ResetDrive()]: #ResetDrive
 [SetUpInternals()]: #SetUpInternals
 [Implements]: #Implements

--- a/Documentation/API/AngularDriver/AngularJointDrive.md
+++ b/Documentation/API/AngularDriver/AngularJointDrive.md
@@ -42,8 +42,6 @@ IProcessable
 
 ##### Inherited Members
 
-[AngularDrive.ResetRotationsOnSetup]
-
 [AngularDrive.PreviousActualAngle]
 
 [AngularDrive.CurrentActualAngle]
@@ -70,7 +68,7 @@ IProcessable
 
 [AngularDrive.Process()]
 
-[AngularDrive.ResetRotations()]
+[AngularDrive.ResetDrive()]
 
 [AngularDrive.CalculateDriveLimits(AngularDriveFacade)]
 
@@ -91,6 +89,10 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.Facade]
 
 [Drive<AngularDriveFacade, AngularDrive>.EventOutputContainer]
+
+[Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetup]
+
+[Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetupFirstTimeOnly]
 
 [Drive<AngularDriveFacade, AngularDrive>.TargetValueReachedThreshold]
 
@@ -128,6 +130,8 @@ IProcessable
 
 [Drive<AngularDriveFacade, AngularDrive>.cachedDriveSpeed]
 
+[Drive<AngularDriveFacade, AngularDrive>.ConfigureAutoDrive(Boolean)]
+
 [Drive<AngularDriveFacade, AngularDrive>.SetUp()]
 
 [Drive<AngularDriveFacade, AngularDrive>.Process()]
@@ -142,7 +146,7 @@ IProcessable
 
 [Drive<AngularDriveFacade, AngularDrive>.CalculateDriveAxis(DriveAxis.Axis)]
 
-[Drive<AngularDriveFacade, AngularDrive>.ConfigureAutoDrive(Boolean)]
+[Drive<AngularDriveFacade, AngularDrive>.ResetDrive()]
 
 [Drive<AngularDriveFacade, AngularDrive>.CalculateValue(DriveAxis.Axis, FloatRange)]
 
@@ -431,7 +435,6 @@ IProcessable
 [Drive]: ../Driver/Drive-2.md
 [AngularDriveFacade]: AngularDriveFacade.md
 [AngularDrive]: AngularDrive.md
-[AngularDrive.ResetRotationsOnSetup]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_ResetRotationsOnSetup
 [AngularDrive.PreviousActualAngle]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_PreviousActualAngle
 [AngularDrive.CurrentActualAngle]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_CurrentActualAngle
 [AngularDrive.ActualTargetAngle]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_ActualTargetAngle
@@ -445,7 +448,7 @@ IProcessable
 [AngularDrive.previousActualRotation]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_previousActualRotation
 [AngularDrive.currentActualRotation]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_currentActualRotation
 [AngularDrive.Process()]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_Process
-[AngularDrive.ResetRotations()]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_ResetRotations
+[AngularDrive.ResetDrive()]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_ResetDrive
 [AngularDrive.CalculateDriveLimits(AngularDriveFacade)]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_CalculateDriveLimits_Tilia_Interactions_Controllables_AngularDriver_AngularDriveFacade_
 [AngularDrive.CalculateValue(DriveAxis.Axis, FloatRange)]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_CalculateValue_Tilia_Interactions_Controllables_Driver_DriveAxis_Axis_FloatRange_
 [AngularDrive.GetSimpleEulerAngles()]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_GetSimpleEulerAngles
@@ -456,6 +459,8 @@ IProcessable
 [AngularDrive.MatchActualTargetAngle(Single)]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_MatchActualTargetAngle_System_Single_
 [Drive<AngularDriveFacade, AngularDrive>.Facade]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Facade
 [Drive<AngularDriveFacade, AngularDrive>.EventOutputContainer]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EventOutputContainer
+[Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetup]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetup
+[Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetupFirstTimeOnly]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetupFirstTimeOnly
 [Drive<AngularDriveFacade, AngularDrive>.TargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_TargetValueReachedThreshold
 [Drive<AngularDriveFacade, AngularDrive>.EmitEvents]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitEvents
 [Drive<AngularDriveFacade, AngularDrive>.Value]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Value
@@ -474,6 +479,7 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.cachedMoveToTargetValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedMoveToTargetValue
 [Drive<AngularDriveFacade, AngularDrive>.cachedTargetValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedTargetValue
 [Drive<AngularDriveFacade, AngularDrive>.cachedDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedDriveSpeed
+[Drive<AngularDriveFacade, AngularDrive>.ConfigureAutoDrive(Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ConfigureAutoDrive_System_Boolean_
 [Drive<AngularDriveFacade, AngularDrive>.SetUp()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetUp
 [Drive<AngularDriveFacade, AngularDrive>.Process()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Process
 [Drive<AngularDriveFacade, AngularDrive>.SetDriveLimits()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetDriveLimits
@@ -481,7 +487,7 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.ProcessDriveSpeed(Single, Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ProcessDriveSpeed_System_Single_System_Boolean_
 [Drive<AngularDriveFacade, AngularDrive>.SetTargetValue(Single)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetTargetValue_System_Single_
 [Drive<AngularDriveFacade, AngularDrive>.CalculateDriveAxis(DriveAxis.Axis)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateDriveAxis_Tilia_Interactions_Controllables_Driver_DriveAxis_Axis_
-[Drive<AngularDriveFacade, AngularDrive>.ConfigureAutoDrive(Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ConfigureAutoDrive_System_Boolean_
+[Drive<AngularDriveFacade, AngularDrive>.ResetDrive()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDrive
 [Drive<AngularDriveFacade, AngularDrive>.CalculateValue(DriveAxis.Axis, FloatRange)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateValue_Tilia_Interactions_Controllables_Driver_DriveAxis_Axis_FloatRange_
 [Drive<AngularDriveFacade, AngularDrive>.CalculateDriveLimits(AngularDriveFacade)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateDriveLimits__0_
 [Drive<AngularDriveFacade, AngularDrive>.GetDriveTransform()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GetDriveTransform

--- a/Documentation/API/AngularDriver/AngularTransformDrive.md
+++ b/Documentation/API/AngularDriver/AngularTransformDrive.md
@@ -37,8 +37,6 @@ IProcessable
 
 ##### Inherited Members
 
-[AngularDrive.ResetRotationsOnSetup]
-
 [AngularDrive.PreviousActualAngle]
 
 [AngularDrive.CurrentActualAngle]
@@ -65,7 +63,7 @@ IProcessable
 
 [AngularDrive.Process()]
 
-[AngularDrive.ResetRotations()]
+[AngularDrive.ResetDrive()]
 
 [AngularDrive.SetUpInternals()]
 
@@ -88,6 +86,10 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.Facade]
 
 [Drive<AngularDriveFacade, AngularDrive>.EventOutputContainer]
+
+[Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetup]
+
+[Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetupFirstTimeOnly]
 
 [Drive<AngularDriveFacade, AngularDrive>.TargetValueReachedThreshold]
 
@@ -125,6 +127,8 @@ IProcessable
 
 [Drive<AngularDriveFacade, AngularDrive>.cachedDriveSpeed]
 
+[Drive<AngularDriveFacade, AngularDrive>.ConfigureAutoDrive(Boolean)]
+
 [Drive<AngularDriveFacade, AngularDrive>.SetUp()]
 
 [Drive<AngularDriveFacade, AngularDrive>.Process()]
@@ -139,7 +143,7 @@ IProcessable
 
 [Drive<AngularDriveFacade, AngularDrive>.CalculateDriveAxis(DriveAxis.Axis)]
 
-[Drive<AngularDriveFacade, AngularDrive>.ConfigureAutoDrive(Boolean)]
+[Drive<AngularDriveFacade, AngularDrive>.ResetDrive()]
 
 [Drive<AngularDriveFacade, AngularDrive>.CalculateValue(DriveAxis.Axis, FloatRange)]
 
@@ -372,7 +376,6 @@ IProcessable
 [Drive]: ../Driver/Drive-2.md
 [AngularDriveFacade]: AngularDriveFacade.md
 [AngularDrive]: AngularDrive.md
-[AngularDrive.ResetRotationsOnSetup]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_ResetRotationsOnSetup
 [AngularDrive.PreviousActualAngle]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_PreviousActualAngle
 [AngularDrive.CurrentActualAngle]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_CurrentActualAngle
 [AngularDrive.ActualTargetAngle]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_ActualTargetAngle
@@ -386,7 +389,7 @@ IProcessable
 [AngularDrive.previousActualRotation]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_previousActualRotation
 [AngularDrive.currentActualRotation]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_currentActualRotation
 [AngularDrive.Process()]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_Process
-[AngularDrive.ResetRotations()]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_ResetRotations
+[AngularDrive.ResetDrive()]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_ResetDrive
 [AngularDrive.SetUpInternals()]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_SetUpInternals
 [AngularDrive.CalculateDriveLimits(AngularDriveFacade)]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_CalculateDriveLimits_Tilia_Interactions_Controllables_AngularDriver_AngularDriveFacade_
 [AngularDrive.CalculateValue(DriveAxis.Axis, FloatRange)]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_CalculateValue_Tilia_Interactions_Controllables_Driver_DriveAxis_Axis_FloatRange_
@@ -398,6 +401,8 @@ IProcessable
 [AngularDrive.MatchActualTargetAngle(Single)]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_MatchActualTargetAngle_System_Single_
 [Drive<AngularDriveFacade, AngularDrive>.Facade]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Facade
 [Drive<AngularDriveFacade, AngularDrive>.EventOutputContainer]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EventOutputContainer
+[Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetup]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetup
+[Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetupFirstTimeOnly]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetupFirstTimeOnly
 [Drive<AngularDriveFacade, AngularDrive>.TargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_TargetValueReachedThreshold
 [Drive<AngularDriveFacade, AngularDrive>.EmitEvents]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitEvents
 [Drive<AngularDriveFacade, AngularDrive>.Value]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Value
@@ -416,6 +421,7 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.cachedMoveToTargetValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedMoveToTargetValue
 [Drive<AngularDriveFacade, AngularDrive>.cachedTargetValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedTargetValue
 [Drive<AngularDriveFacade, AngularDrive>.cachedDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedDriveSpeed
+[Drive<AngularDriveFacade, AngularDrive>.ConfigureAutoDrive(Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ConfigureAutoDrive_System_Boolean_
 [Drive<AngularDriveFacade, AngularDrive>.SetUp()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetUp
 [Drive<AngularDriveFacade, AngularDrive>.Process()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Process
 [Drive<AngularDriveFacade, AngularDrive>.SetDriveLimits()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetDriveLimits
@@ -423,7 +429,7 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.ProcessDriveSpeed(Single, Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ProcessDriveSpeed_System_Single_System_Boolean_
 [Drive<AngularDriveFacade, AngularDrive>.SetTargetValue(Single)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetTargetValue_System_Single_
 [Drive<AngularDriveFacade, AngularDrive>.CalculateDriveAxis(DriveAxis.Axis)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateDriveAxis_Tilia_Interactions_Controllables_Driver_DriveAxis_Axis_
-[Drive<AngularDriveFacade, AngularDrive>.ConfigureAutoDrive(Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ConfigureAutoDrive_System_Boolean_
+[Drive<AngularDriveFacade, AngularDrive>.ResetDrive()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDrive
 [Drive<AngularDriveFacade, AngularDrive>.CalculateValue(DriveAxis.Axis, FloatRange)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateValue_Tilia_Interactions_Controllables_Driver_DriveAxis_Axis_FloatRange_
 [Drive<AngularDriveFacade, AngularDrive>.CalculateDriveLimits(AngularDriveFacade)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateDriveLimits__0_
 [Drive<AngularDriveFacade, AngularDrive>.GetDriveTransform()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GetDriveTransform

--- a/Documentation/API/Driver/Drive-2.md
+++ b/Documentation/API/Driver/Drive-2.md
@@ -26,6 +26,8 @@ The basis for a mechanism to drive motion on a control.
   * [Facade]
   * [NormalizedStepValue]
   * [NormalizedValue]
+  * [ResetDriveOnSetup]
+  * [ResetDriveOnSetupFirstTimeOnly]
   * [StepValue]
   * [TargetValueReachedThreshold]
   * [Value]
@@ -49,6 +51,7 @@ The basis for a mechanism to drive motion on a control.
   * [OnEnable()]
   * [Process()]
   * [ProcessDriveSpeed(Single, Boolean)]
+  * [ResetDrive()]
   * [ResetToCacheAfterReachedInitialTargetValue()]
   * [SetAxisDirection()]
   * [SetDriveLimits()]
@@ -260,6 +263,26 @@ The current normalized value for the drive control between the set limits.
 
 ```
 public float NormalizedValue { get; }
+```
+
+#### ResetDriveOnSetup
+
+Whether to reset the drive data when [SetUp()] is executed.
+
+##### Declaration
+
+```
+public bool ResetDriveOnSetup { get; set; }
+```
+
+#### ResetDriveOnSetupFirstTimeOnly
+
+Whether to set the [ResetDriveOnSetup] property back to false after [SetUp()] has executed to prevent future automatic resets until the value is manually changed again.
+
+##### Declaration
+
+```
+public bool ResetDriveOnSetupFirstTimeOnly { get; set; }
 ```
 
 #### StepValue
@@ -562,6 +585,16 @@ public virtual void ProcessDriveSpeed(float driveSpeed, bool moveToTargetValue)
 | System.Single | driveSpeed | The speed to drive the control at. |
 | System.Boolean | moveToTargetValue | Whether to allow the drive to automatically move the control to the desired target value. |
 
+#### ResetDrive()
+
+Resets the drive back to any default settings.
+
+##### Declaration
+
+```
+public virtual void ResetDrive()
+```
+
 #### ResetToCacheAfterReachedInitialTargetValue()
 
 Resets the drive parameters to the cached values after the initial target value is reached.
@@ -655,6 +688,9 @@ IProcessable
 [EmitEvents]: Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitEvents
 [StepValue]: Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_StepValue
 [Value]: Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Value
+[SetUp()]: Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetUp
+[ResetDriveOnSetup]: Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetup
+[SetUp()]: Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetUp
 [DriveAxis.Axis]: DriveAxis.Axis.md
 [AxisDirection]: Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_AxisDirection
 [DriveLimits]: Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_DriveLimits
@@ -681,6 +717,8 @@ IProcessable
 [Facade]: #Facade
 [NormalizedStepValue]: #NormalizedStepValue
 [NormalizedValue]: #NormalizedValue
+[ResetDriveOnSetup]: #ResetDriveOnSetup
+[ResetDriveOnSetupFirstTimeOnly]: #ResetDriveOnSetupFirstTimeOnly
 [StepValue]: #StepValue
 [TargetValueReachedThreshold]: #TargetValueReachedThreshold
 [Value]: #Value
@@ -704,6 +742,7 @@ IProcessable
 [OnEnable()]: #OnEnable
 [Process()]: #Process
 [ProcessDriveSpeed(Single, Boolean)]: #ProcessDriveSpeedSingle-Boolean
+[ResetDrive()]: #ResetDrive
 [ResetToCacheAfterReachedInitialTargetValue()]: #ResetToCacheAfterReachedInitialTargetValue
 [SetAxisDirection()]: #SetAxisDirection
 [SetDriveLimits()]: #SetDriveLimits

--- a/Documentation/API/LinearDriver/LinearDrive.md
+++ b/Documentation/API/LinearDriver/LinearDrive.md
@@ -34,6 +34,10 @@ IProcessable
 
 [Drive<LinearDriveFacade, LinearDrive>.EventOutputContainer]
 
+[Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetup]
+
+[Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetupFirstTimeOnly]
+
 [Drive<LinearDriveFacade, LinearDrive>.TargetValueReachedThreshold]
 
 [Drive<LinearDriveFacade, LinearDrive>.EmitEvents]
@@ -70,6 +74,8 @@ IProcessable
 
 [Drive<LinearDriveFacade, LinearDrive>.cachedDriveSpeed]
 
+[Drive<LinearDriveFacade, LinearDrive>.ConfigureAutoDrive(Boolean)]
+
 [Drive<LinearDriveFacade, LinearDrive>.SetUp()]
 
 [Drive<LinearDriveFacade, LinearDrive>.Process()]
@@ -84,7 +90,7 @@ IProcessable
 
 [Drive<LinearDriveFacade, LinearDrive>.CalculateDriveAxis(DriveAxis.Axis)]
 
-[Drive<LinearDriveFacade, LinearDrive>.ConfigureAutoDrive(Boolean)]
+[Drive<LinearDriveFacade, LinearDrive>.ResetDrive()]
 
 [Drive<LinearDriveFacade, LinearDrive>.CalculateValue(DriveAxis.Axis, FloatRange)]
 
@@ -239,6 +245,8 @@ IProcessable
 [LinearTransformDrive]: LinearTransformDrive.md
 [Drive<LinearDriveFacade, LinearDrive>.Facade]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Facade
 [Drive<LinearDriveFacade, LinearDrive>.EventOutputContainer]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EventOutputContainer
+[Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetup]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetup
+[Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetupFirstTimeOnly]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetupFirstTimeOnly
 [Drive<LinearDriveFacade, LinearDrive>.TargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_TargetValueReachedThreshold
 [Drive<LinearDriveFacade, LinearDrive>.EmitEvents]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitEvents
 [Drive<LinearDriveFacade, LinearDrive>.Value]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Value
@@ -257,6 +265,7 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.cachedMoveToTargetValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedMoveToTargetValue
 [Drive<LinearDriveFacade, LinearDrive>.cachedTargetValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedTargetValue
 [Drive<LinearDriveFacade, LinearDrive>.cachedDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedDriveSpeed
+[Drive<LinearDriveFacade, LinearDrive>.ConfigureAutoDrive(Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ConfigureAutoDrive_System_Boolean_
 [Drive<LinearDriveFacade, LinearDrive>.SetUp()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetUp
 [Drive<LinearDriveFacade, LinearDrive>.Process()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Process
 [Drive<LinearDriveFacade, LinearDrive>.SetDriveLimits()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetDriveLimits
@@ -264,7 +273,7 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.ProcessDriveSpeed(Single, Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ProcessDriveSpeed_System_Single_System_Boolean_
 [Drive<LinearDriveFacade, LinearDrive>.SetTargetValue(Single)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetTargetValue_System_Single_
 [Drive<LinearDriveFacade, LinearDrive>.CalculateDriveAxis(DriveAxis.Axis)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateDriveAxis_Tilia_Interactions_Controllables_Driver_DriveAxis_Axis_
-[Drive<LinearDriveFacade, LinearDrive>.ConfigureAutoDrive(Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ConfigureAutoDrive_System_Boolean_
+[Drive<LinearDriveFacade, LinearDrive>.ResetDrive()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDrive
 [Drive<LinearDriveFacade, LinearDrive>.CalculateValue(DriveAxis.Axis, FloatRange)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateValue_Tilia_Interactions_Controllables_Driver_DriveAxis_Axis_FloatRange_
 [Drive<LinearDriveFacade, LinearDrive>.CalculateDriveLimits(LinearDriveFacade)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateDriveLimits__0_
 [Drive<LinearDriveFacade, LinearDrive>.GetDriveTransform()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GetDriveTransform

--- a/Documentation/API/LinearDriver/LinearJointDrive.md
+++ b/Documentation/API/LinearDriver/LinearJointDrive.md
@@ -46,6 +46,10 @@ IProcessable
 
 [Drive<LinearDriveFacade, LinearDrive>.EventOutputContainer]
 
+[Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetup]
+
+[Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetupFirstTimeOnly]
+
 [Drive<LinearDriveFacade, LinearDrive>.TargetValueReachedThreshold]
 
 [Drive<LinearDriveFacade, LinearDrive>.EmitEvents]
@@ -82,6 +86,8 @@ IProcessable
 
 [Drive<LinearDriveFacade, LinearDrive>.cachedDriveSpeed]
 
+[Drive<LinearDriveFacade, LinearDrive>.ConfigureAutoDrive(Boolean)]
+
 [Drive<LinearDriveFacade, LinearDrive>.SetUp()]
 
 [Drive<LinearDriveFacade, LinearDrive>.Process()]
@@ -96,7 +102,7 @@ IProcessable
 
 [Drive<LinearDriveFacade, LinearDrive>.CalculateDriveAxis(DriveAxis.Axis)]
 
-[Drive<LinearDriveFacade, LinearDrive>.ConfigureAutoDrive(Boolean)]
+[Drive<LinearDriveFacade, LinearDrive>.ResetDrive()]
 
 [Drive<LinearDriveFacade, LinearDrive>.CalculateValue(DriveAxis.Axis, FloatRange)]
 
@@ -323,6 +329,8 @@ IProcessable
 [LinearDrive.ConfigureAutoDrive(Boolean)]: LinearDrive.md#Tilia_Interactions_Controllables_LinearDriver_LinearDrive_ConfigureAutoDrive_System_Boolean_
 [Drive<LinearDriveFacade, LinearDrive>.Facade]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Facade
 [Drive<LinearDriveFacade, LinearDrive>.EventOutputContainer]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EventOutputContainer
+[Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetup]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetup
+[Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetupFirstTimeOnly]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetupFirstTimeOnly
 [Drive<LinearDriveFacade, LinearDrive>.TargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_TargetValueReachedThreshold
 [Drive<LinearDriveFacade, LinearDrive>.EmitEvents]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitEvents
 [Drive<LinearDriveFacade, LinearDrive>.Value]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Value
@@ -341,6 +349,7 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.cachedMoveToTargetValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedMoveToTargetValue
 [Drive<LinearDriveFacade, LinearDrive>.cachedTargetValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedTargetValue
 [Drive<LinearDriveFacade, LinearDrive>.cachedDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedDriveSpeed
+[Drive<LinearDriveFacade, LinearDrive>.ConfigureAutoDrive(Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ConfigureAutoDrive_System_Boolean_
 [Drive<LinearDriveFacade, LinearDrive>.SetUp()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetUp
 [Drive<LinearDriveFacade, LinearDrive>.Process()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Process
 [Drive<LinearDriveFacade, LinearDrive>.SetDriveLimits()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetDriveLimits
@@ -348,7 +357,7 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.ProcessDriveSpeed(Single, Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ProcessDriveSpeed_System_Single_System_Boolean_
 [Drive<LinearDriveFacade, LinearDrive>.SetTargetValue(Single)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetTargetValue_System_Single_
 [Drive<LinearDriveFacade, LinearDrive>.CalculateDriveAxis(DriveAxis.Axis)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateDriveAxis_Tilia_Interactions_Controllables_Driver_DriveAxis_Axis_
-[Drive<LinearDriveFacade, LinearDrive>.ConfigureAutoDrive(Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ConfigureAutoDrive_System_Boolean_
+[Drive<LinearDriveFacade, LinearDrive>.ResetDrive()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDrive
 [Drive<LinearDriveFacade, LinearDrive>.CalculateValue(DriveAxis.Axis, FloatRange)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateValue_Tilia_Interactions_Controllables_Driver_DriveAxis_Axis_FloatRange_
 [Drive<LinearDriveFacade, LinearDrive>.CalculateDriveLimits(LinearDriveFacade)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateDriveLimits__0_
 [Drive<LinearDriveFacade, LinearDrive>.GetDriveTransform()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GetDriveTransform

--- a/Documentation/API/LinearDriver/LinearTransformDrive.md
+++ b/Documentation/API/LinearDriver/LinearTransformDrive.md
@@ -46,6 +46,10 @@ IProcessable
 
 [Drive<LinearDriveFacade, LinearDrive>.EventOutputContainer]
 
+[Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetup]
+
+[Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetupFirstTimeOnly]
+
 [Drive<LinearDriveFacade, LinearDrive>.TargetValueReachedThreshold]
 
 [Drive<LinearDriveFacade, LinearDrive>.EmitEvents]
@@ -82,6 +86,8 @@ IProcessable
 
 [Drive<LinearDriveFacade, LinearDrive>.cachedDriveSpeed]
 
+[Drive<LinearDriveFacade, LinearDrive>.ConfigureAutoDrive(Boolean)]
+
 [Drive<LinearDriveFacade, LinearDrive>.SetUp()]
 
 [Drive<LinearDriveFacade, LinearDrive>.Process()]
@@ -96,7 +102,7 @@ IProcessable
 
 [Drive<LinearDriveFacade, LinearDrive>.CalculateDriveAxis(DriveAxis.Axis)]
 
-[Drive<LinearDriveFacade, LinearDrive>.ConfigureAutoDrive(Boolean)]
+[Drive<LinearDriveFacade, LinearDrive>.ResetDrive()]
 
 [Drive<LinearDriveFacade, LinearDrive>.CalculateValue(DriveAxis.Axis, FloatRange)]
 
@@ -292,6 +298,8 @@ IProcessable
 [LinearDrive.ConfigureAutoDrive(Boolean)]: LinearDrive.md#Tilia_Interactions_Controllables_LinearDriver_LinearDrive_ConfigureAutoDrive_System_Boolean_
 [Drive<LinearDriveFacade, LinearDrive>.Facade]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Facade
 [Drive<LinearDriveFacade, LinearDrive>.EventOutputContainer]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EventOutputContainer
+[Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetup]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetup
+[Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetupFirstTimeOnly]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetupFirstTimeOnly
 [Drive<LinearDriveFacade, LinearDrive>.TargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_TargetValueReachedThreshold
 [Drive<LinearDriveFacade, LinearDrive>.EmitEvents]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitEvents
 [Drive<LinearDriveFacade, LinearDrive>.Value]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Value
@@ -310,6 +318,7 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.cachedMoveToTargetValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedMoveToTargetValue
 [Drive<LinearDriveFacade, LinearDrive>.cachedTargetValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedTargetValue
 [Drive<LinearDriveFacade, LinearDrive>.cachedDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedDriveSpeed
+[Drive<LinearDriveFacade, LinearDrive>.ConfigureAutoDrive(Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ConfigureAutoDrive_System_Boolean_
 [Drive<LinearDriveFacade, LinearDrive>.SetUp()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetUp
 [Drive<LinearDriveFacade, LinearDrive>.Process()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Process
 [Drive<LinearDriveFacade, LinearDrive>.SetDriveLimits()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetDriveLimits
@@ -317,7 +326,7 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.ProcessDriveSpeed(Single, Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ProcessDriveSpeed_System_Single_System_Boolean_
 [Drive<LinearDriveFacade, LinearDrive>.SetTargetValue(Single)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetTargetValue_System_Single_
 [Drive<LinearDriveFacade, LinearDrive>.CalculateDriveAxis(DriveAxis.Axis)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateDriveAxis_Tilia_Interactions_Controllables_Driver_DriveAxis_Axis_
-[Drive<LinearDriveFacade, LinearDrive>.ConfigureAutoDrive(Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ConfigureAutoDrive_System_Boolean_
+[Drive<LinearDriveFacade, LinearDrive>.ResetDrive()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDrive
 [Drive<LinearDriveFacade, LinearDrive>.CalculateValue(DriveAxis.Axis, FloatRange)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateValue_Tilia_Interactions_Controllables_Driver_DriveAxis_Axis_FloatRange_
 [Drive<LinearDriveFacade, LinearDrive>.CalculateDriveLimits(LinearDriveFacade)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateDriveLimits__0_
 [Drive<LinearDriveFacade, LinearDrive>.GetDriveTransform()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GetDriveTransform

--- a/Runtime/Prefabs/PhysicsJoint/Interactions.AngularJointDrive.prefab
+++ b/Runtime/Prefabs/PhysicsJoint/Interactions.AngularJointDrive.prefab
@@ -48,9 +48,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   facade: {fileID: 7220336169150892439}
   eventOutputContainer: {fileID: 6704188405665079684}
+  resetDriveOnSetup: 1
+  resetDriveOnSetupFirstTimeOnly: 1
   targetValueReachedThreshold: 0.075
   emitEvents: 1
-  resetRotationsOnSetup: 1
   joint: {fileID: 1471341665110845562}
   jointContainer: {fileID: 5306551537282979864}
 --- !u!114 &8646993169910720069
@@ -801,16 +802,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3648960081298957348, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
-        type: 3}
-      propertyPath: primaryAction
-      value: 
-      objectReference: {fileID: 4070728723303430929}
-    - target: {fileID: 3648960081298957348, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
-        type: 3}
-      propertyPath: secondaryAction
-      value: 
-      objectReference: {fileID: 7610232722202251261}
     - target: {fileID: 785982709505707726, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
         type: 3}
       propertyPath: FirstGrabbed.m_PersistentCalls.m_Calls.Array.size
@@ -891,6 +882,16 @@ PrefabInstance:
       propertyPath: consumerRigidbody
       value: 
       objectReference: {fileID: 7881770749639878687}
+    - target: {fileID: 3648960081298957348, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
+        type: 3}
+      propertyPath: primaryAction
+      value: 
+      objectReference: {fileID: 4070728723303430929}
+    - target: {fileID: 3648960081298957348, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
+        type: 3}
+      propertyPath: secondaryAction
+      value: 
+      objectReference: {fileID: 7610232722202251261}
     - target: {fileID: 8140612074155134679, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
         type: 3}
       propertyPath: ActiveAndEnabled.m_PersistentCalls.m_Calls.Array.data[0].m_Target

--- a/Runtime/Prefabs/PhysicsJoint/Interactions.LinearJointDrive.prefab
+++ b/Runtime/Prefabs/PhysicsJoint/Interactions.LinearJointDrive.prefab
@@ -465,6 +465,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   facade: {fileID: 2321230931700777055}
   eventOutputContainer: {fileID: 7344147712558315100}
+  resetDriveOnSetup: 1
+  resetDriveOnSetupFirstTimeOnly: 1
   targetValueReachedThreshold: 0.025
   emitEvents: 1
   joint: {fileID: 2051297999214337113}
@@ -810,16 +812,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3648960081298957348, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
-        type: 3}
-      propertyPath: primaryAction
-      value: 
-      objectReference: {fileID: 113661431433796937}
-    - target: {fileID: 3648960081298957348, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
-        type: 3}
-      propertyPath: secondaryAction
-      value: 
-      objectReference: {fileID: 5759501801176164688}
     - target: {fileID: 6666400304308521552, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
         type: 3}
       propertyPath: consumerContainer
@@ -830,6 +822,16 @@ PrefabInstance:
       propertyPath: consumerRigidbody
       value: 
       objectReference: {fileID: 835135679342871320}
+    - target: {fileID: 3648960081298957348, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
+        type: 3}
+      propertyPath: primaryAction
+      value: 
+      objectReference: {fileID: 113661431433796937}
+    - target: {fileID: 3648960081298957348, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
+        type: 3}
+      propertyPath: secondaryAction
+      value: 
+      objectReference: {fileID: 5759501801176164688}
     - target: {fileID: 8140612074155134679, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
         type: 3}
       propertyPath: ActiveAndEnabled.m_PersistentCalls.m_Calls.Array.data[0].m_Target

--- a/Runtime/Prefabs/Transform/Interactions.AngularTransformDrive.prefab
+++ b/Runtime/Prefabs/Transform/Interactions.AngularTransformDrive.prefab
@@ -178,9 +178,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   facade: {fileID: 2116566820272827043}
   eventOutputContainer: {fileID: 6134235524921124102}
+  resetDriveOnSetup: 1
+  resetDriveOnSetupFirstTimeOnly: 1
   targetValueReachedThreshold: 0.075
   emitEvents: 1
-  resetRotationsOnSetup: 1
   interactable: {fileID: 4763570561051037854}
   interactableMesh: {fileID: 6582222421973241952}
   rotationModifier: {fileID: 9194919288075826165}
@@ -495,7 +496,7 @@ PrefabInstance:
       propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
-    - target: {fileID: 6240288194601417652, guid: 702caa48c730e92469a1c5144fd8ed46,
+    - target: {fileID: 1659144888459829164, guid: 702caa48c730e92469a1c5144fd8ed46,
         type: 3}
       propertyPath: Emitted.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
       value: 2
@@ -540,7 +541,7 @@ PrefabInstance:
       propertyPath: Emitted.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_FloatArgument
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1659144888459829164, guid: 702caa48c730e92469a1c5144fd8ed46,
+    - target: {fileID: 6240288194601417652, guid: 702caa48c730e92469a1c5144fd8ed46,
         type: 3}
       propertyPath: Emitted.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
       value: 2

--- a/Runtime/Prefabs/Transform/Interactions.LinearTransformDrive.prefab
+++ b/Runtime/Prefabs/Transform/Interactions.LinearTransformDrive.prefab
@@ -697,6 +697,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   facade: {fileID: 7040976075344879994}
   eventOutputContainer: {fileID: 7468202290724158542}
+  resetDriveOnSetup: 1
+  resetDriveOnSetupFirstTimeOnly: 1
   targetValueReachedThreshold: 0.025
   emitEvents: 1
   interactable: {fileID: 7736847107121358400}
@@ -1119,6 +1121,11 @@ PrefabInstance:
       propertyPath: isKinematicWhenInactive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 4534934962641631106, guid: 702caa48c730e92469a1c5144fd8ed46,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3860205902975461033, guid: 702caa48c730e92469a1c5144fd8ed46,
         type: 3}
       propertyPath: Modified.m_PersistentCalls.m_Calls.Array.size
@@ -1148,11 +1155,6 @@ PrefabInstance:
         type: 3}
       propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
-      objectReference: {fileID: 0}
-    - target: {fileID: 4534934962641631106, guid: 702caa48c730e92469a1c5144fd8ed46,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4297763714491022842, guid: 702caa48c730e92469a1c5144fd8ed46,
         type: 3}

--- a/Runtime/SharedResources/Scripts/AngularDriver/AngularDrive.cs
+++ b/Runtime/SharedResources/Scripts/AngularDriver/AngularDrive.cs
@@ -1,8 +1,6 @@
 ﻿namespace Tilia.Interactions.Controllables.AngularDriver
 {
     using Malimbe.BehaviourStateRequirementMethod;
-    using Malimbe.PropertySerializationAttribute;
-    using Malimbe.XmlDocumentationAttribute;
     using Tilia.Interactions.Controllables.Driver;
     using UnityEngine;
     using Zinnia.Data.Type;
@@ -13,15 +11,6 @@
     /// </summary>
     public abstract class AngularDrive : Drive<AngularDriveFacade, AngularDrive>
     {
-        #region Rotation Settings
-        /// <summary>
-        /// The joint being used to drive the rotation.
-        /// </summary>
-        [Serialized]
-        [field: Header("Rotation Settings"), DocumentedByXml]
-        public bool ResetRotationsOnSetup { get; set; } = true;
-        #endregion
-
         /// <summary>
         /// The previous rotation angle of the control.
         /// </summary>
@@ -106,12 +95,14 @@
             MatchActualTargetAngle(autoDriveTargetVelocity);
         }
 
-        /// <summary>
-        /// Resets the <see cref="Transform"/> rotation data.
-        /// </summary>
-        public virtual void ResetRotations()
+        /// <inheritdoc />
+        public override void ResetDrive()
         {
+            base.ResetDrive();
             GetDriveTransform().localRotation = Quaternion.identity;
+            previousActualRotation = Vector3.zero;
+            currentActualRotation = GetSimpleEulerAngles();
+            rotationMultiplier = 0f;
             previousPseudoRotation = 0f;
             currentPseudoRotation = 0f;
             pseudoAngularVelocity = 0f;
@@ -126,10 +117,6 @@
         /// <inheritdoc />
         protected override void SetUpInternals()
         {
-            if (ResetRotationsOnSetup)
-            {
-                ResetRotations();
-            }
             ConfigureAutoDrive(Facade.MoveToTargetValue);
             CalculateHingeLocation(Facade.HingeLocation);
         }

--- a/Runtime/SharedResources/Scripts/Driver/Drive.cs
+++ b/Runtime/SharedResources/Scripts/Driver/Drive.cs
@@ -31,6 +31,21 @@
         public GameObject EventOutputContainer { get; protected set; }
         #endregion
 
+        #region Drive Settings
+        /// <summary>
+        /// Whether to reset the drive data when <see cref="SetUp"/> is executed.
+        /// </summary>
+        [Serialized]
+        [field: Header("Drive Settings"), DocumentedByXml]
+        public bool ResetDriveOnSetup { get; set; } = true;
+        /// <summary>
+        /// Whether to set the <see cref="ResetDriveOnSetup"/> property back to <see cref="false"/> after <see cref="SetUp"/> has executed to prevent future automatic resets until the value is manually changed again.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public bool ResetDriveOnSetupFirstTimeOnly { get; set; } = true;
+        #endregion
+
         #region Target Settings
         /// <summary>
         /// The threshold that the current normalized value of the control can be within to consider the target value has been reached.
@@ -113,11 +128,22 @@
         protected float cachedDriveSpeed;
 
         /// <summary>
+        /// Configures the ability to automatically drive the control.
+        /// </summary>
+        /// <param name="autoDrive">Whether the drive can automatically drive the control.</param>
+        public virtual void ConfigureAutoDrive(bool autoDrive) { }
+
+        /// <summary>
         /// Sets up the drive mechanism.
         /// </summary>
         [RequiresBehaviourState]
         public virtual void SetUp()
         {
+            if (ResetDriveOnSetup)
+            {
+                ResetDrive();
+            }
+
             SetUpInternals();
             SetDriveLimits();
             SetAxisDirection();
@@ -215,10 +241,16 @@
         }
 
         /// <summary>
-        /// Configures the ability to automatically drive the control.
+        /// Resets the drive back to any default settings.
         /// </summary>
-        /// <param name="autoDrive">Whether the drive can automatically drive the control.</param>
-        public virtual void ConfigureAutoDrive(bool autoDrive) { }
+        [RequiresBehaviourState]
+        public virtual void ResetDrive()
+        {
+            if (ResetDriveOnSetupFirstTimeOnly)
+            {
+                ResetDriveOnSetup = false;
+            }
+        }
 
         /// <summary>
         /// Calculates the current value of the control.

--- a/Runtime/SharedResources/Scripts/Driver/DriveFacade.cs
+++ b/Runtime/SharedResources/Scripts/Driver/DriveFacade.cs
@@ -231,6 +231,7 @@
         [CalledAfterChangeOf(nameof(DriveAxis))]
         protected virtual void OnAfterDriveAxisChange()
         {
+            Drive.ResetDriveOnSetup = true;
             Drive.SetUp();
         }
 


### PR DESCRIPTION
The AngularDrive ResetRotations was causing the MoveToTargetValue
functionality to break because it was always resetting the drive
everytime the target value changed. This has been fixed by reworking
the Reset concept into the core Drive class and having the ability
of only calling ResetDrive the first time SetUp is called and then it
won't call Reset again until a manual intervention occurs.