### PR TITLE
fix(Drive): expose initial drive value speed as public property - fixes #55

### DIFF
--- a/Documentation/API/AngularDriver/AngularDrive.md
+++ b/Documentation/API/AngularDriver/AngularDrive.md
@@ -63,6 +63,8 @@ IProcessable
 
 [Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetupFirstTimeOnly]
 
+[Drive<AngularDriveFacade, AngularDrive>.InitialValueDriveSpeed]
+
 [Drive<AngularDriveFacade, AngularDrive>.TargetValueReachedThreshold]
 
 [Drive<AngularDriveFacade, AngularDrive>.EmitEvents]
@@ -78,8 +80,6 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.AxisDirection]
 
 [Drive<AngularDriveFacade, AngularDrive>.DriveLimits]
-
-[Drive<AngularDriveFacade, AngularDrive>.initialValueDriveSpeed]
 
 [Drive<AngularDriveFacade, AngularDrive>.previousValue]
 
@@ -542,6 +542,7 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.EventOutputContainer]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EventOutputContainer
 [Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetup]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetup
 [Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetupFirstTimeOnly]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetupFirstTimeOnly
+[Drive<AngularDriveFacade, AngularDrive>.InitialValueDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_InitialValueDriveSpeed
 [Drive<AngularDriveFacade, AngularDrive>.TargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_TargetValueReachedThreshold
 [Drive<AngularDriveFacade, AngularDrive>.EmitEvents]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitEvents
 [Drive<AngularDriveFacade, AngularDrive>.Value]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Value
@@ -550,7 +551,6 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.NormalizedStepValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_NormalizedStepValue
 [Drive<AngularDriveFacade, AngularDrive>.AxisDirection]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_AxisDirection
 [Drive<AngularDriveFacade, AngularDrive>.DriveLimits]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_DriveLimits
-[Drive<AngularDriveFacade, AngularDrive>.initialValueDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_initialValueDriveSpeed
 [Drive<AngularDriveFacade, AngularDrive>.previousValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_previousValue
 [Drive<AngularDriveFacade, AngularDrive>.previousStepValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_previousStepValue
 [Drive<AngularDriveFacade, AngularDrive>.previousTargetValueReached]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_previousTargetValueReached

--- a/Documentation/API/AngularDriver/AngularJointDrive.md
+++ b/Documentation/API/AngularDriver/AngularJointDrive.md
@@ -94,6 +94,8 @@ IProcessable
 
 [Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetupFirstTimeOnly]
 
+[Drive<AngularDriveFacade, AngularDrive>.InitialValueDriveSpeed]
+
 [Drive<AngularDriveFacade, AngularDrive>.TargetValueReachedThreshold]
 
 [Drive<AngularDriveFacade, AngularDrive>.EmitEvents]
@@ -109,8 +111,6 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.AxisDirection]
 
 [Drive<AngularDriveFacade, AngularDrive>.DriveLimits]
-
-[Drive<AngularDriveFacade, AngularDrive>.initialValueDriveSpeed]
 
 [Drive<AngularDriveFacade, AngularDrive>.previousValue]
 
@@ -461,6 +461,7 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.EventOutputContainer]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EventOutputContainer
 [Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetup]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetup
 [Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetupFirstTimeOnly]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetupFirstTimeOnly
+[Drive<AngularDriveFacade, AngularDrive>.InitialValueDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_InitialValueDriveSpeed
 [Drive<AngularDriveFacade, AngularDrive>.TargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_TargetValueReachedThreshold
 [Drive<AngularDriveFacade, AngularDrive>.EmitEvents]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitEvents
 [Drive<AngularDriveFacade, AngularDrive>.Value]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Value
@@ -469,7 +470,6 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.NormalizedStepValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_NormalizedStepValue
 [Drive<AngularDriveFacade, AngularDrive>.AxisDirection]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_AxisDirection
 [Drive<AngularDriveFacade, AngularDrive>.DriveLimits]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_DriveLimits
-[Drive<AngularDriveFacade, AngularDrive>.initialValueDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_initialValueDriveSpeed
 [Drive<AngularDriveFacade, AngularDrive>.previousValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_previousValue
 [Drive<AngularDriveFacade, AngularDrive>.previousStepValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_previousStepValue
 [Drive<AngularDriveFacade, AngularDrive>.previousTargetValueReached]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_previousTargetValueReached

--- a/Documentation/API/AngularDriver/AngularTransformDrive.md
+++ b/Documentation/API/AngularDriver/AngularTransformDrive.md
@@ -91,6 +91,8 @@ IProcessable
 
 [Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetupFirstTimeOnly]
 
+[Drive<AngularDriveFacade, AngularDrive>.InitialValueDriveSpeed]
+
 [Drive<AngularDriveFacade, AngularDrive>.TargetValueReachedThreshold]
 
 [Drive<AngularDriveFacade, AngularDrive>.EmitEvents]
@@ -106,8 +108,6 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.AxisDirection]
 
 [Drive<AngularDriveFacade, AngularDrive>.DriveLimits]
-
-[Drive<AngularDriveFacade, AngularDrive>.initialValueDriveSpeed]
 
 [Drive<AngularDriveFacade, AngularDrive>.previousValue]
 
@@ -403,6 +403,7 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.EventOutputContainer]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EventOutputContainer
 [Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetup]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetup
 [Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetupFirstTimeOnly]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetupFirstTimeOnly
+[Drive<AngularDriveFacade, AngularDrive>.InitialValueDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_InitialValueDriveSpeed
 [Drive<AngularDriveFacade, AngularDrive>.TargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_TargetValueReachedThreshold
 [Drive<AngularDriveFacade, AngularDrive>.EmitEvents]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitEvents
 [Drive<AngularDriveFacade, AngularDrive>.Value]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Value
@@ -411,7 +412,6 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.NormalizedStepValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_NormalizedStepValue
 [Drive<AngularDriveFacade, AngularDrive>.AxisDirection]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_AxisDirection
 [Drive<AngularDriveFacade, AngularDrive>.DriveLimits]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_DriveLimits
-[Drive<AngularDriveFacade, AngularDrive>.initialValueDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_initialValueDriveSpeed
 [Drive<AngularDriveFacade, AngularDrive>.previousValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_previousValue
 [Drive<AngularDriveFacade, AngularDrive>.previousStepValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_previousStepValue
 [Drive<AngularDriveFacade, AngularDrive>.previousTargetValueReached]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_previousTargetValueReached

--- a/Documentation/API/Driver/Drive-2.md
+++ b/Documentation/API/Driver/Drive-2.md
@@ -12,7 +12,6 @@ The basis for a mechanism to drive motion on a control.
   * [cachedEmitEvents]
   * [cachedMoveToTargetValue]
   * [cachedTargetValue]
-  * [initialValueDriveSpeed]
   * [isMoving]
   * [isMovingToInitialTargetValue]
   * [previousStepValue]
@@ -24,6 +23,7 @@ The basis for a mechanism to drive motion on a control.
   * [EmitEvents]
   * [EventOutputContainer]
   * [Facade]
+  * [InitialValueDriveSpeed]
   * [NormalizedStepValue]
   * [NormalizedValue]
   * [ResetDriveOnSetup]
@@ -133,16 +133,6 @@ The cached value for TargetValue.
 protected float cachedTargetValue
 ```
 
-#### initialValueDriveSpeed
-
-The value to set the drive speed to when driving the control to the initial start value.
-
-##### Declaration
-
-```
-protected const float initialValueDriveSpeed = 5000F
-```
-
 #### isMoving
 
 Whether the control is moving or not.
@@ -243,6 +233,16 @@ The public interface facade.
 
 ```
 public TFacade Facade { get; protected set; }
+```
+
+#### InitialValueDriveSpeed
+
+The value to set the drive speed to when driving the control to the initial start value.
+
+##### Declaration
+
+```
+public float InitialValueDriveSpeed { get; set; }
 ```
 
 #### NormalizedStepValue
@@ -703,7 +703,6 @@ IProcessable
 [cachedEmitEvents]: #cachedEmitEvents
 [cachedMoveToTargetValue]: #cachedMoveToTargetValue
 [cachedTargetValue]: #cachedTargetValue
-[initialValueDriveSpeed]: #initialValueDriveSpeed
 [isMoving]: #isMoving
 [isMovingToInitialTargetValue]: #isMovingToInitialTargetValue
 [previousStepValue]: #previousStepValue
@@ -715,6 +714,7 @@ IProcessable
 [EmitEvents]: #EmitEvents
 [EventOutputContainer]: #EventOutputContainer
 [Facade]: #Facade
+[InitialValueDriveSpeed]: #InitialValueDriveSpeed
 [NormalizedStepValue]: #NormalizedStepValue
 [NormalizedValue]: #NormalizedValue
 [ResetDriveOnSetup]: #ResetDriveOnSetup

--- a/Documentation/API/LinearDriver/LinearDrive.md
+++ b/Documentation/API/LinearDriver/LinearDrive.md
@@ -38,6 +38,8 @@ IProcessable
 
 [Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetupFirstTimeOnly]
 
+[Drive<LinearDriveFacade, LinearDrive>.InitialValueDriveSpeed]
+
 [Drive<LinearDriveFacade, LinearDrive>.TargetValueReachedThreshold]
 
 [Drive<LinearDriveFacade, LinearDrive>.EmitEvents]
@@ -53,8 +55,6 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.AxisDirection]
 
 [Drive<LinearDriveFacade, LinearDrive>.DriveLimits]
-
-[Drive<LinearDriveFacade, LinearDrive>.initialValueDriveSpeed]
 
 [Drive<LinearDriveFacade, LinearDrive>.previousValue]
 
@@ -247,6 +247,7 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.EventOutputContainer]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EventOutputContainer
 [Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetup]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetup
 [Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetupFirstTimeOnly]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetupFirstTimeOnly
+[Drive<LinearDriveFacade, LinearDrive>.InitialValueDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_InitialValueDriveSpeed
 [Drive<LinearDriveFacade, LinearDrive>.TargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_TargetValueReachedThreshold
 [Drive<LinearDriveFacade, LinearDrive>.EmitEvents]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitEvents
 [Drive<LinearDriveFacade, LinearDrive>.Value]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Value
@@ -255,7 +256,6 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.NormalizedStepValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_NormalizedStepValue
 [Drive<LinearDriveFacade, LinearDrive>.AxisDirection]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_AxisDirection
 [Drive<LinearDriveFacade, LinearDrive>.DriveLimits]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_DriveLimits
-[Drive<LinearDriveFacade, LinearDrive>.initialValueDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_initialValueDriveSpeed
 [Drive<LinearDriveFacade, LinearDrive>.previousValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_previousValue
 [Drive<LinearDriveFacade, LinearDrive>.previousStepValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_previousStepValue
 [Drive<LinearDriveFacade, LinearDrive>.previousTargetValueReached]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_previousTargetValueReached

--- a/Documentation/API/LinearDriver/LinearJointDrive.md
+++ b/Documentation/API/LinearDriver/LinearJointDrive.md
@@ -50,6 +50,8 @@ IProcessable
 
 [Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetupFirstTimeOnly]
 
+[Drive<LinearDriveFacade, LinearDrive>.InitialValueDriveSpeed]
+
 [Drive<LinearDriveFacade, LinearDrive>.TargetValueReachedThreshold]
 
 [Drive<LinearDriveFacade, LinearDrive>.EmitEvents]
@@ -65,8 +67,6 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.AxisDirection]
 
 [Drive<LinearDriveFacade, LinearDrive>.DriveLimits]
-
-[Drive<LinearDriveFacade, LinearDrive>.initialValueDriveSpeed]
 
 [Drive<LinearDriveFacade, LinearDrive>.previousValue]
 
@@ -331,6 +331,7 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.EventOutputContainer]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EventOutputContainer
 [Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetup]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetup
 [Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetupFirstTimeOnly]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetupFirstTimeOnly
+[Drive<LinearDriveFacade, LinearDrive>.InitialValueDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_InitialValueDriveSpeed
 [Drive<LinearDriveFacade, LinearDrive>.TargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_TargetValueReachedThreshold
 [Drive<LinearDriveFacade, LinearDrive>.EmitEvents]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitEvents
 [Drive<LinearDriveFacade, LinearDrive>.Value]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Value
@@ -339,7 +340,6 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.NormalizedStepValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_NormalizedStepValue
 [Drive<LinearDriveFacade, LinearDrive>.AxisDirection]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_AxisDirection
 [Drive<LinearDriveFacade, LinearDrive>.DriveLimits]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_DriveLimits
-[Drive<LinearDriveFacade, LinearDrive>.initialValueDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_initialValueDriveSpeed
 [Drive<LinearDriveFacade, LinearDrive>.previousValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_previousValue
 [Drive<LinearDriveFacade, LinearDrive>.previousStepValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_previousStepValue
 [Drive<LinearDriveFacade, LinearDrive>.previousTargetValueReached]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_previousTargetValueReached

--- a/Documentation/API/LinearDriver/LinearTransformDrive.md
+++ b/Documentation/API/LinearDriver/LinearTransformDrive.md
@@ -50,6 +50,8 @@ IProcessable
 
 [Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetupFirstTimeOnly]
 
+[Drive<LinearDriveFacade, LinearDrive>.InitialValueDriveSpeed]
+
 [Drive<LinearDriveFacade, LinearDrive>.TargetValueReachedThreshold]
 
 [Drive<LinearDriveFacade, LinearDrive>.EmitEvents]
@@ -65,8 +67,6 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.AxisDirection]
 
 [Drive<LinearDriveFacade, LinearDrive>.DriveLimits]
-
-[Drive<LinearDriveFacade, LinearDrive>.initialValueDriveSpeed]
 
 [Drive<LinearDriveFacade, LinearDrive>.previousValue]
 
@@ -300,6 +300,7 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.EventOutputContainer]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EventOutputContainer
 [Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetup]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetup
 [Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetupFirstTimeOnly]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetupFirstTimeOnly
+[Drive<LinearDriveFacade, LinearDrive>.InitialValueDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_InitialValueDriveSpeed
 [Drive<LinearDriveFacade, LinearDrive>.TargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_TargetValueReachedThreshold
 [Drive<LinearDriveFacade, LinearDrive>.EmitEvents]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitEvents
 [Drive<LinearDriveFacade, LinearDrive>.Value]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Value
@@ -308,7 +309,6 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.NormalizedStepValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_NormalizedStepValue
 [Drive<LinearDriveFacade, LinearDrive>.AxisDirection]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_AxisDirection
 [Drive<LinearDriveFacade, LinearDrive>.DriveLimits]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_DriveLimits
-[Drive<LinearDriveFacade, LinearDrive>.initialValueDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_initialValueDriveSpeed
 [Drive<LinearDriveFacade, LinearDrive>.previousValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_previousValue
 [Drive<LinearDriveFacade, LinearDrive>.previousStepValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_previousStepValue
 [Drive<LinearDriveFacade, LinearDrive>.previousTargetValueReached]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_previousTargetValueReached

--- a/Runtime/Prefabs/Transform/Interactions.AngularTransformDrive.prefab
+++ b/Runtime/Prefabs/Transform/Interactions.AngularTransformDrive.prefab
@@ -180,6 +180,7 @@ MonoBehaviour:
   eventOutputContainer: {fileID: 6134235524921124102}
   resetDriveOnSetup: 1
   resetDriveOnSetupFirstTimeOnly: 1
+  initialValueDriveSpeed: 3500
   targetValueReachedThreshold: 0.075
   emitEvents: 1
   interactable: {fileID: 4763570561051037854}
@@ -496,7 +497,7 @@ PrefabInstance:
       propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
-    - target: {fileID: 1659144888459829164, guid: 702caa48c730e92469a1c5144fd8ed46,
+    - target: {fileID: 6240288194601417652, guid: 702caa48c730e92469a1c5144fd8ed46,
         type: 3}
       propertyPath: Emitted.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
       value: 2
@@ -541,7 +542,7 @@ PrefabInstance:
       propertyPath: Emitted.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_FloatArgument
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6240288194601417652, guid: 702caa48c730e92469a1c5144fd8ed46,
+    - target: {fileID: 1659144888459829164, guid: 702caa48c730e92469a1c5144fd8ed46,
         type: 3}
       propertyPath: Emitted.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
       value: 2

--- a/Runtime/SharedResources/Scripts/Driver/Drive.cs
+++ b/Runtime/SharedResources/Scripts/Driver/Drive.cs
@@ -44,6 +44,12 @@
         [Serialized]
         [field: DocumentedByXml]
         public bool ResetDriveOnSetupFirstTimeOnly { get; set; } = true;
+        /// <summary>
+        /// The value to set the drive speed to when driving the control to the initial start value.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public float InitialValueDriveSpeed { get; set; } = 5000f;
         #endregion
 
         #region Target Settings
@@ -86,10 +92,6 @@
         /// </summary>
         public FloatRange DriveLimits { get; protected set; }
 
-        /// <summary>
-        /// The value to set the drive speed to when driving the control to the initial start value.
-        /// </summary>
-        protected const float initialValueDriveSpeed = 5000f;
         /// <summary>
         /// The previous state of <see cref="Value"/>.
         /// </summary>
@@ -424,7 +426,7 @@
             EmitEvents = false;
             Facade.MoveToTargetValue = true;
             Facade.TargetValue = Facade.InitialTargetValue;
-            Facade.DriveSpeed = initialValueDriveSpeed;
+            Facade.DriveSpeed = InitialValueDriveSpeed;
             SetUp();
         }
 


### PR DESCRIPTION
The IntialDriveValueSpeed is now a public changable property rather
than a protected constant field so it can be adapted to suit different
requirements.

The AngularTransformDrive did not work well at such a high speed so
it has now been reduced to make it work correctly using this new
ability to publicly set the initial speed of the drive.