### PR TITLE
fix(Drive): calculate correct step value for increments other than 1

### DIFF
--- a/Runtime/SharedResources/Scripts/Driver/Drive.cs
+++ b/Runtime/SharedResources/Scripts/Driver/Drive.cs
@@ -320,7 +320,7 @@
         /// <returns>The calculated step value.</returns>
         protected virtual float CalculateStepValue(TFacade facade)
         {
-            return Mathf.Round(Mathf.Lerp(facade.StepRange.minimum / facade.StepIncrement, facade.StepRange.maximum / facade.StepIncrement, NormalizedValue));
+            return Mathf.Round(Mathf.Lerp(facade.StepRange.minimum / facade.StepIncrement, facade.StepRange.maximum / facade.StepIncrement, NormalizedValue)) * facade.StepIncrement;
         }
 
         /// <summary>


### PR DESCRIPTION
The Step Value calculation was only working if the Step Increment value
was 1 because the final value should be multiplied by the Step
Increment value but it wasn't. It is now being multiplied correctly.