### PR TITLE
fix(Drive): process the drive correctly after disable and re-enable - fixes #76

### DIFF
--- a/Documentation/API/AngularDriver/AngularDrive.md
+++ b/Documentation/API/AngularDriver/AngularDrive.md
@@ -99,6 +99,8 @@ IProcessable
 
 [Drive<AngularDriveFacade, AngularDrive>.cachedDriveSpeed]
 
+[Drive<AngularDriveFacade, AngularDrive>.wasDisabled]
+
 [Drive<AngularDriveFacade, AngularDrive>.ConfigureAutoDrive(Boolean)]
 
 [Drive<AngularDriveFacade, AngularDrive>.SetUp()]
@@ -124,6 +126,8 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.GetDriveTransform()]
 
 [Drive<AngularDriveFacade, AngularDrive>.OnEnable()]
+
+[Drive<AngularDriveFacade, AngularDrive>.OnDisable()]
 
 [Drive<AngularDriveFacade, AngularDrive>.SetUpInternals()]
 
@@ -560,6 +564,7 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.cachedMoveToTargetValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedMoveToTargetValue
 [Drive<AngularDriveFacade, AngularDrive>.cachedTargetValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedTargetValue
 [Drive<AngularDriveFacade, AngularDrive>.cachedDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedDriveSpeed
+[Drive<AngularDriveFacade, AngularDrive>.wasDisabled]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_wasDisabled
 [Drive<AngularDriveFacade, AngularDrive>.ConfigureAutoDrive(Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ConfigureAutoDrive_System_Boolean_
 [Drive<AngularDriveFacade, AngularDrive>.SetUp()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetUp
 [Drive<AngularDriveFacade, AngularDrive>.Process()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Process
@@ -573,6 +578,7 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.CalculateDriveLimits(AngularDriveFacade)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateDriveLimits__0_
 [Drive<AngularDriveFacade, AngularDrive>.GetDriveTransform()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GetDriveTransform
 [Drive<AngularDriveFacade, AngularDrive>.OnEnable()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_OnEnable
+[Drive<AngularDriveFacade, AngularDrive>.OnDisable()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_OnDisable
 [Drive<AngularDriveFacade, AngularDrive>.SetUpInternals()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetUpInternals
 [Drive<AngularDriveFacade, AngularDrive>.SetDriveTargetValue(Vector3)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetDriveTargetValue_Vector3_
 [Drive<AngularDriveFacade, AngularDrive>.EliminateDriveVelocity()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EliminateDriveVelocity

--- a/Documentation/API/AngularDriver/AngularJointDrive.md
+++ b/Documentation/API/AngularDriver/AngularJointDrive.md
@@ -130,6 +130,8 @@ IProcessable
 
 [Drive<AngularDriveFacade, AngularDrive>.cachedDriveSpeed]
 
+[Drive<AngularDriveFacade, AngularDrive>.wasDisabled]
+
 [Drive<AngularDriveFacade, AngularDrive>.ConfigureAutoDrive(Boolean)]
 
 [Drive<AngularDriveFacade, AngularDrive>.SetUp()]
@@ -155,6 +157,8 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.GetDriveTransform()]
 
 [Drive<AngularDriveFacade, AngularDrive>.OnEnable()]
+
+[Drive<AngularDriveFacade, AngularDrive>.OnDisable()]
 
 [Drive<AngularDriveFacade, AngularDrive>.SetUpInternals()]
 
@@ -479,6 +483,7 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.cachedMoveToTargetValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedMoveToTargetValue
 [Drive<AngularDriveFacade, AngularDrive>.cachedTargetValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedTargetValue
 [Drive<AngularDriveFacade, AngularDrive>.cachedDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedDriveSpeed
+[Drive<AngularDriveFacade, AngularDrive>.wasDisabled]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_wasDisabled
 [Drive<AngularDriveFacade, AngularDrive>.ConfigureAutoDrive(Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ConfigureAutoDrive_System_Boolean_
 [Drive<AngularDriveFacade, AngularDrive>.SetUp()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetUp
 [Drive<AngularDriveFacade, AngularDrive>.Process()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Process
@@ -492,6 +497,7 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.CalculateDriveLimits(AngularDriveFacade)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateDriveLimits__0_
 [Drive<AngularDriveFacade, AngularDrive>.GetDriveTransform()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GetDriveTransform
 [Drive<AngularDriveFacade, AngularDrive>.OnEnable()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_OnEnable
+[Drive<AngularDriveFacade, AngularDrive>.OnDisable()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_OnDisable
 [Drive<AngularDriveFacade, AngularDrive>.SetUpInternals()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetUpInternals
 [Drive<AngularDriveFacade, AngularDrive>.SetDriveTargetValue(Vector3)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetDriveTargetValue_Vector3_
 [Drive<AngularDriveFacade, AngularDrive>.EliminateDriveVelocity()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EliminateDriveVelocity

--- a/Documentation/API/AngularDriver/AngularTransformDrive.md
+++ b/Documentation/API/AngularDriver/AngularTransformDrive.md
@@ -127,6 +127,8 @@ IProcessable
 
 [Drive<AngularDriveFacade, AngularDrive>.cachedDriveSpeed]
 
+[Drive<AngularDriveFacade, AngularDrive>.wasDisabled]
+
 [Drive<AngularDriveFacade, AngularDrive>.ConfigureAutoDrive(Boolean)]
 
 [Drive<AngularDriveFacade, AngularDrive>.SetUp()]
@@ -152,6 +154,8 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.GetDriveTransform()]
 
 [Drive<AngularDriveFacade, AngularDrive>.OnEnable()]
+
+[Drive<AngularDriveFacade, AngularDrive>.OnDisable()]
 
 [Drive<AngularDriveFacade, AngularDrive>.SetUpInternals()]
 
@@ -421,6 +425,7 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.cachedMoveToTargetValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedMoveToTargetValue
 [Drive<AngularDriveFacade, AngularDrive>.cachedTargetValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedTargetValue
 [Drive<AngularDriveFacade, AngularDrive>.cachedDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedDriveSpeed
+[Drive<AngularDriveFacade, AngularDrive>.wasDisabled]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_wasDisabled
 [Drive<AngularDriveFacade, AngularDrive>.ConfigureAutoDrive(Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ConfigureAutoDrive_System_Boolean_
 [Drive<AngularDriveFacade, AngularDrive>.SetUp()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetUp
 [Drive<AngularDriveFacade, AngularDrive>.Process()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Process
@@ -434,6 +439,7 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.CalculateDriveLimits(AngularDriveFacade)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateDriveLimits__0_
 [Drive<AngularDriveFacade, AngularDrive>.GetDriveTransform()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GetDriveTransform
 [Drive<AngularDriveFacade, AngularDrive>.OnEnable()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_OnEnable
+[Drive<AngularDriveFacade, AngularDrive>.OnDisable()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_OnDisable
 [Drive<AngularDriveFacade, AngularDrive>.SetUpInternals()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetUpInternals
 [Drive<AngularDriveFacade, AngularDrive>.SetDriveTargetValue(Vector3)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetDriveTargetValue_Vector3_
 [Drive<AngularDriveFacade, AngularDrive>.EliminateDriveVelocity()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EliminateDriveVelocity

--- a/Documentation/API/Driver/Drive-2.md
+++ b/Documentation/API/Driver/Drive-2.md
@@ -17,6 +17,7 @@ The basis for a mechanism to drive motion on a control.
   * [previousStepValue]
   * [previousTargetValueReached]
   * [previousValue]
+  * [wasDisabled]
 * [Properties]
   * [AxisDirection]
   * [DriveLimits]
@@ -48,6 +49,7 @@ The basis for a mechanism to drive motion on a control.
   * [GetDriveTransform()]
   * [GetTargetValue()]
   * [MoveToInitialTargetValue()]
+  * [OnDisable()]
   * [OnEnable()]
   * [Process()]
   * [ProcessDriveSpeed(Single, Boolean)]
@@ -181,6 +183,16 @@ The previous state of [Value].
 
 ```
 protected float previousValue
+```
+
+#### wasDisabled
+
+Whether this component has previously been disabled before the next process.
+
+##### Declaration
+
+```
+protected bool wasDisabled
 ```
 
 ### Properties
@@ -550,6 +562,14 @@ Moves the drive to the initial target value.
 protected virtual void MoveToInitialTargetValue()
 ```
 
+#### OnDisable()
+
+##### Declaration
+
+```
+protected virtual void OnDisable()
+```
+
 #### OnEnable()
 
 ##### Declaration
@@ -708,6 +728,7 @@ IProcessable
 [previousStepValue]: #previousStepValue
 [previousTargetValueReached]: #previousTargetValueReached
 [previousValue]: #previousValue
+[wasDisabled]: #wasDisabled
 [Properties]: #Properties
 [AxisDirection]: #AxisDirection
 [DriveLimits]: #DriveLimits
@@ -739,6 +760,7 @@ IProcessable
 [GetDriveTransform()]: #GetDriveTransform
 [GetTargetValue()]: #GetTargetValue
 [MoveToInitialTargetValue()]: #MoveToInitialTargetValue
+[OnDisable()]: #OnDisable
 [OnEnable()]: #OnEnable
 [Process()]: #Process
 [ProcessDriveSpeed(Single, Boolean)]: #ProcessDriveSpeedSingle-Boolean

--- a/Documentation/API/LinearDriver/LinearDrive.md
+++ b/Documentation/API/LinearDriver/LinearDrive.md
@@ -74,6 +74,8 @@ IProcessable
 
 [Drive<LinearDriveFacade, LinearDrive>.cachedDriveSpeed]
 
+[Drive<LinearDriveFacade, LinearDrive>.wasDisabled]
+
 [Drive<LinearDriveFacade, LinearDrive>.ConfigureAutoDrive(Boolean)]
 
 [Drive<LinearDriveFacade, LinearDrive>.SetUp()]
@@ -99,6 +101,8 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.GetDriveTransform()]
 
 [Drive<LinearDriveFacade, LinearDrive>.OnEnable()]
+
+[Drive<LinearDriveFacade, LinearDrive>.OnDisable()]
 
 [Drive<LinearDriveFacade, LinearDrive>.SetUpInternals()]
 
@@ -265,6 +269,7 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.cachedMoveToTargetValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedMoveToTargetValue
 [Drive<LinearDriveFacade, LinearDrive>.cachedTargetValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedTargetValue
 [Drive<LinearDriveFacade, LinearDrive>.cachedDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedDriveSpeed
+[Drive<LinearDriveFacade, LinearDrive>.wasDisabled]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_wasDisabled
 [Drive<LinearDriveFacade, LinearDrive>.ConfigureAutoDrive(Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ConfigureAutoDrive_System_Boolean_
 [Drive<LinearDriveFacade, LinearDrive>.SetUp()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetUp
 [Drive<LinearDriveFacade, LinearDrive>.Process()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Process
@@ -278,6 +283,7 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.CalculateDriveLimits(LinearDriveFacade)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateDriveLimits__0_
 [Drive<LinearDriveFacade, LinearDrive>.GetDriveTransform()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GetDriveTransform
 [Drive<LinearDriveFacade, LinearDrive>.OnEnable()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_OnEnable
+[Drive<LinearDriveFacade, LinearDrive>.OnDisable()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_OnDisable
 [Drive<LinearDriveFacade, LinearDrive>.SetUpInternals()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetUpInternals
 [Drive<LinearDriveFacade, LinearDrive>.SetDriveTargetValue(Vector3)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetDriveTargetValue_Vector3_
 [Drive<LinearDriveFacade, LinearDrive>.EliminateDriveVelocity()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EliminateDriveVelocity

--- a/Documentation/API/LinearDriver/LinearJointDrive.md
+++ b/Documentation/API/LinearDriver/LinearJointDrive.md
@@ -86,6 +86,8 @@ IProcessable
 
 [Drive<LinearDriveFacade, LinearDrive>.cachedDriveSpeed]
 
+[Drive<LinearDriveFacade, LinearDrive>.wasDisabled]
+
 [Drive<LinearDriveFacade, LinearDrive>.ConfigureAutoDrive(Boolean)]
 
 [Drive<LinearDriveFacade, LinearDrive>.SetUp()]
@@ -111,6 +113,8 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.GetDriveTransform()]
 
 [Drive<LinearDriveFacade, LinearDrive>.OnEnable()]
+
+[Drive<LinearDriveFacade, LinearDrive>.OnDisable()]
 
 [Drive<LinearDriveFacade, LinearDrive>.SetUpInternals()]
 
@@ -349,6 +353,7 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.cachedMoveToTargetValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedMoveToTargetValue
 [Drive<LinearDriveFacade, LinearDrive>.cachedTargetValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedTargetValue
 [Drive<LinearDriveFacade, LinearDrive>.cachedDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedDriveSpeed
+[Drive<LinearDriveFacade, LinearDrive>.wasDisabled]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_wasDisabled
 [Drive<LinearDriveFacade, LinearDrive>.ConfigureAutoDrive(Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ConfigureAutoDrive_System_Boolean_
 [Drive<LinearDriveFacade, LinearDrive>.SetUp()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetUp
 [Drive<LinearDriveFacade, LinearDrive>.Process()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Process
@@ -362,6 +367,7 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.CalculateDriveLimits(LinearDriveFacade)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateDriveLimits__0_
 [Drive<LinearDriveFacade, LinearDrive>.GetDriveTransform()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GetDriveTransform
 [Drive<LinearDriveFacade, LinearDrive>.OnEnable()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_OnEnable
+[Drive<LinearDriveFacade, LinearDrive>.OnDisable()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_OnDisable
 [Drive<LinearDriveFacade, LinearDrive>.SetUpInternals()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetUpInternals
 [Drive<LinearDriveFacade, LinearDrive>.SetDriveTargetValue(Vector3)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetDriveTargetValue_Vector3_
 [Drive<LinearDriveFacade, LinearDrive>.EliminateDriveVelocity()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EliminateDriveVelocity

--- a/Documentation/API/LinearDriver/LinearTransformDrive.md
+++ b/Documentation/API/LinearDriver/LinearTransformDrive.md
@@ -86,6 +86,8 @@ IProcessable
 
 [Drive<LinearDriveFacade, LinearDrive>.cachedDriveSpeed]
 
+[Drive<LinearDriveFacade, LinearDrive>.wasDisabled]
+
 [Drive<LinearDriveFacade, LinearDrive>.ConfigureAutoDrive(Boolean)]
 
 [Drive<LinearDriveFacade, LinearDrive>.SetUp()]
@@ -111,6 +113,8 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.GetDriveTransform()]
 
 [Drive<LinearDriveFacade, LinearDrive>.OnEnable()]
+
+[Drive<LinearDriveFacade, LinearDrive>.OnDisable()]
 
 [Drive<LinearDriveFacade, LinearDrive>.SetUpInternals()]
 
@@ -318,6 +322,7 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.cachedMoveToTargetValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedMoveToTargetValue
 [Drive<LinearDriveFacade, LinearDrive>.cachedTargetValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedTargetValue
 [Drive<LinearDriveFacade, LinearDrive>.cachedDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_cachedDriveSpeed
+[Drive<LinearDriveFacade, LinearDrive>.wasDisabled]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_wasDisabled
 [Drive<LinearDriveFacade, LinearDrive>.ConfigureAutoDrive(Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ConfigureAutoDrive_System_Boolean_
 [Drive<LinearDriveFacade, LinearDrive>.SetUp()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetUp
 [Drive<LinearDriveFacade, LinearDrive>.Process()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Process
@@ -331,6 +336,7 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.CalculateDriveLimits(LinearDriveFacade)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateDriveLimits__0_
 [Drive<LinearDriveFacade, LinearDrive>.GetDriveTransform()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GetDriveTransform
 [Drive<LinearDriveFacade, LinearDrive>.OnEnable()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_OnEnable
+[Drive<LinearDriveFacade, LinearDrive>.OnDisable()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_OnDisable
 [Drive<LinearDriveFacade, LinearDrive>.SetUpInternals()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetUpInternals
 [Drive<LinearDriveFacade, LinearDrive>.SetDriveTargetValue(Vector3)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetDriveTargetValue_Vector3_
 [Drive<LinearDriveFacade, LinearDrive>.EliminateDriveVelocity()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EliminateDriveVelocity

--- a/Runtime/SharedResources/Scripts/Driver/Drive.cs
+++ b/Runtime/SharedResources/Scripts/Driver/Drive.cs
@@ -128,6 +128,10 @@
         /// The cached value for <see cref="DriveSpeed"/>.
         /// </summary>
         protected float cachedDriveSpeed;
+        /// <summary>
+        /// Whether this component has previously been disabled before the next process.
+        /// </summary>
+        protected bool wasDisabled;
 
         /// <summary>
         /// Configures the ability to automatically drive the control.
@@ -159,7 +163,7 @@
         [RequiresBehaviourState]
         public virtual void Process()
         {
-            if (!Value.ApproxEquals(previousValue))
+            if (wasDisabled || !Value.ApproxEquals(previousValue))
             {
                 if (!isMoving && previousValue < float.MaxValue)
                 {
@@ -194,6 +198,8 @@
             {
                 EmitTargetValueReached();
             }
+
+            wasDisabled = false;
         }
 
         /// <summary>
@@ -277,6 +283,11 @@
         {
             SetUp();
             MoveToInitialTargetValue();
+        }
+
+        protected virtual void OnDisable()
+        {
+            wasDisabled = true;
         }
 
         /// <summary>


### PR DESCRIPTION
There was an issue where the drive would not correctly run the process
code after it was disabled and re-enabled because the process code
relied on the fact that the drive would start in a central position
and move to a different location which would allow the process
mechanism to operate because the value delta has changed.

But upon disabling and re-enabling, the value of the button location
would be the same causing no process to occur which would then in turn
prevent the events from being emitted.

This fix just ensures that upon disable and re-enable the process at
least happens once to ensure the correct set up occurs.