### PR TITLE
feat(DriveFacade): add object reference links to common nested objects - resolves #49

### DIFF
--- a/Documentation/API/AngularDriver/AngularDriveFacade.md
+++ b/Documentation/API/AngularDriver/AngularDriveFacade.md
@@ -34,6 +34,14 @@ The public interface into any RotationalDrive prefab.
 
 [DriveFacade<AngularDrive, AngularDriveFacade>.Drive]
 
+[DriveFacade<AngularDrive, AngularDriveFacade>.LinkedInteractableFacade]
+
+[DriveFacade<AngularDrive, AngularDriveFacade>.LinkedMinReached]
+
+[DriveFacade<AngularDrive, AngularDriveFacade>.LinkedMidReached]
+
+[DriveFacade<AngularDrive, AngularDriveFacade>.LinkedMaxReached]
+
 [DriveFacade<AngularDrive, AngularDriveFacade>.ValueChanged]
 
 [DriveFacade<AngularDrive, AngularDriveFacade>.StepValueChanged]
@@ -262,6 +270,10 @@ public virtual void SetHingeLocationZ(float value)
 [AngularDrive]: AngularDrive.md
 [AngularDriveFacade]: AngularDriveFacade.md
 [DriveFacade<AngularDrive, AngularDriveFacade>.Drive]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_Drive
+[DriveFacade<AngularDrive, AngularDriveFacade>.LinkedInteractableFacade]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_LinkedInteractableFacade
+[DriveFacade<AngularDrive, AngularDriveFacade>.LinkedMinReached]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_LinkedMinReached
+[DriveFacade<AngularDrive, AngularDriveFacade>.LinkedMidReached]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_LinkedMidReached
+[DriveFacade<AngularDrive, AngularDriveFacade>.LinkedMaxReached]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_LinkedMaxReached
 [DriveFacade<AngularDrive, AngularDriveFacade>.ValueChanged]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_ValueChanged
 [DriveFacade<AngularDrive, AngularDriveFacade>.StepValueChanged]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_StepValueChanged
 [DriveFacade<AngularDrive, AngularDriveFacade>.NormalizedValueChanged]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_NormalizedValueChanged

--- a/Documentation/API/Driver/DriveFacade-2.md
+++ b/Documentation/API/Driver/DriveFacade-2.md
@@ -20,6 +20,10 @@ The basis of the public interface that will drive a control in relation to a spe
   * [DriveAxis]
   * [DriveSpeed]
   * [InitialTargetValue]
+  * [LinkedInteractableFacade]
+  * [LinkedMaxReached]
+  * [LinkedMidReached]
+  * [LinkedMinReached]
   * [MoveToTargetValue]
   * [StartAtInitialTargetValue]
   * [StepIncrement]
@@ -181,6 +185,46 @@ The normalized value to attempt to drive the control to when it is first enabled
 
 ```
 public float InitialTargetValue { get; set; }
+```
+
+#### LinkedInteractableFacade
+
+The GameObject reference for the nested Interactable/>.
+
+##### Declaration
+
+```
+public ObjectReference LinkedInteractableFacade { get; protected set; }
+```
+
+#### LinkedMaxReached
+
+The GameObject reference for the nested max value reached event/>.
+
+##### Declaration
+
+```
+public ObjectReference LinkedMaxReached { get; protected set; }
+```
+
+#### LinkedMidReached
+
+The GameObject reference for the nested mid point value reached event/>.
+
+##### Declaration
+
+```
+public ObjectReference LinkedMidReached { get; protected set; }
+```
+
+#### LinkedMinReached
+
+The GameObject reference for the nested minimum value reached event/>.
+
+##### Declaration
+
+```
+public ObjectReference LinkedMinReached { get; protected set; }
 ```
 
 #### MoveToTargetValue
@@ -490,6 +534,10 @@ public virtual void SetTargetValueByStepValue(float stepValue)
 [DriveAxis]: #DriveAxis
 [DriveSpeed]: #DriveSpeed
 [InitialTargetValue]: #InitialTargetValue
+[LinkedInteractableFacade]: #LinkedInteractableFacade
+[LinkedMaxReached]: #LinkedMaxReached
+[LinkedMidReached]: #LinkedMidReached
+[LinkedMinReached]: #LinkedMinReached
 [MoveToTargetValue]: #MoveToTargetValue
 [StartAtInitialTargetValue]: #StartAtInitialTargetValue
 [StepIncrement]: #StepIncrement

--- a/Documentation/API/LinearDriver/LinearDriveFacade.md
+++ b/Documentation/API/LinearDriver/LinearDriveFacade.md
@@ -26,6 +26,14 @@ The public interface into any Linear Drive prefab.
 
 [DriveFacade<LinearDrive, LinearDriveFacade>.Drive]
 
+[DriveFacade<LinearDrive, LinearDriveFacade>.LinkedInteractableFacade]
+
+[DriveFacade<LinearDrive, LinearDriveFacade>.LinkedMinReached]
+
+[DriveFacade<LinearDrive, LinearDriveFacade>.LinkedMidReached]
+
+[DriveFacade<LinearDrive, LinearDriveFacade>.LinkedMaxReached]
+
 [DriveFacade<LinearDrive, LinearDriveFacade>.ValueChanged]
 
 [DriveFacade<LinearDrive, LinearDriveFacade>.StepValueChanged]
@@ -144,6 +152,10 @@ protected virtual void OnDrawGizmosSelected()
 [LinearDrive]: LinearDrive.md
 [LinearDriveFacade]: LinearDriveFacade.md
 [DriveFacade<LinearDrive, LinearDriveFacade>.Drive]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_Drive
+[DriveFacade<LinearDrive, LinearDriveFacade>.LinkedInteractableFacade]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_LinkedInteractableFacade
+[DriveFacade<LinearDrive, LinearDriveFacade>.LinkedMinReached]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_LinkedMinReached
+[DriveFacade<LinearDrive, LinearDriveFacade>.LinkedMidReached]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_LinkedMidReached
+[DriveFacade<LinearDrive, LinearDriveFacade>.LinkedMaxReached]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_LinkedMaxReached
 [DriveFacade<LinearDrive, LinearDriveFacade>.ValueChanged]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_ValueChanged
 [DriveFacade<LinearDrive, LinearDriveFacade>.StepValueChanged]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_StepValueChanged
 [DriveFacade<LinearDrive, LinearDriveFacade>.NormalizedValueChanged]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_NormalizedValueChanged

--- a/Runtime/Prefabs/PhysicsJoint/Interactions.AngularJointDrive.prefab
+++ b/Runtime/Prefabs/PhysicsJoint/Interactions.AngularJointDrive.prefab
@@ -50,6 +50,7 @@ MonoBehaviour:
   eventOutputContainer: {fileID: 6704188405665079684}
   resetDriveOnSetup: 1
   resetDriveOnSetupFirstTimeOnly: 1
+  initialValueDriveSpeed: 5000
   targetValueReachedThreshold: 0.075
   emitEvents: 1
   joint: {fileID: 1471341665110845562}
@@ -213,6 +214,22 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   drive: {fileID: 1163718965896345702}
+  linkedInteractableFacade:
+    linkedObject: {fileID: 4094182479458500961}
+    linkText: Show Interactable Facade Container
+    isActive: 1
+  linkedMinReached:
+    linkedObject: {fileID: 8695116446506062057}
+    linkText: Show Minimum Value Reached Action
+    isActive: 1
+  linkedMidReached:
+    linkedObject: {fileID: 5707798751868080109}
+    linkText: Show Middle Value Reached Action
+    isActive: 1
+  linkedMaxReached:
+    linkedObject: {fileID: 1409309735869935637}
+    linkText: Show Maximum Value Reached Action
+    isActive: 1
   ValueChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -699,6 +716,24 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 3970266325296692636}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &8695116446506062057 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5742787135457963381, guid: 28c785035c1675342b9e41fb684b7948,
+    type: 3}
+  m_PrefabInstance: {fileID: 3970266325296692636}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &5707798751868080109 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8660163246180987505, guid: 28c785035c1675342b9e41fb684b7948,
+    type: 3}
+  m_PrefabInstance: {fileID: 3970266325296692636}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1409309735869935637 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2636830725764533641, guid: 28c785035c1675342b9e41fb684b7948,
+    type: 3}
+  m_PrefabInstance: {fileID: 3970266325296692636}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &7541688849528211887 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 6895096941427192883, guid: 28c785035c1675342b9e41fb684b7948,
@@ -802,6 +837,26 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3648960081298957348, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
+        type: 3}
+      propertyPath: primaryAction
+      value: 
+      objectReference: {fileID: 4070728723303430929}
+    - target: {fileID: 3648960081298957348, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
+        type: 3}
+      propertyPath: secondaryAction
+      value: 
+      objectReference: {fileID: 7610232722202251261}
+    - target: {fileID: 6666400304308521552, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
+        type: 3}
+      propertyPath: consumerContainer
+      value: 
+      objectReference: {fileID: 4948483394596960710}
+    - target: {fileID: 6666400304308521552, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
+        type: 3}
+      propertyPath: consumerRigidbody
+      value: 
+      objectReference: {fileID: 7881770749639878687}
     - target: {fileID: 785982709505707726, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
         type: 3}
       propertyPath: FirstGrabbed.m_PersistentCalls.m_Calls.Array.size
@@ -872,26 +927,6 @@ PrefabInstance:
       propertyPath: LastUngrabbed.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_FloatArgument
       value: 0.01
       objectReference: {fileID: 0}
-    - target: {fileID: 6666400304308521552, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
-        type: 3}
-      propertyPath: consumerContainer
-      value: 
-      objectReference: {fileID: 4948483394596960710}
-    - target: {fileID: 6666400304308521552, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
-        type: 3}
-      propertyPath: consumerRigidbody
-      value: 
-      objectReference: {fileID: 7881770749639878687}
-    - target: {fileID: 3648960081298957348, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
-        type: 3}
-      propertyPath: primaryAction
-      value: 
-      objectReference: {fileID: 4070728723303430929}
-    - target: {fileID: 3648960081298957348, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
-        type: 3}
-      propertyPath: secondaryAction
-      value: 
-      objectReference: {fileID: 7610232722202251261}
     - target: {fileID: 8140612074155134679, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
         type: 3}
       propertyPath: ActiveAndEnabled.m_PersistentCalls.m_Calls.Array.data[0].m_Target
@@ -903,6 +938,12 @@ PrefabInstance:
 --- !u!4 &2557462402498593336 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8090891674275893548, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
+    type: 3}
+  m_PrefabInstance: {fileID: 5995823398209049364}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &4094182479458500961 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7774344186399642229, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
     type: 3}
   m_PrefabInstance: {fileID: 5995823398209049364}
   m_PrefabAsset: {fileID: 0}

--- a/Runtime/Prefabs/PhysicsJoint/Interactions.LinearJointDrive.prefab
+++ b/Runtime/Prefabs/PhysicsJoint/Interactions.LinearJointDrive.prefab
@@ -251,6 +251,22 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   drive: {fileID: 5997973356949160921}
+  linkedInteractableFacade:
+    linkedObject: {fileID: 5856373121429202079}
+    linkText: Show Interactable Facade Container
+    isActive: 1
+  linkedMinReached:
+    linkedObject: {fileID: 4632773467267794737}
+    linkText: Show Minimum Value Reached Action
+    isActive: 1
+  linkedMidReached:
+    linkedObject: {fileID: 8635515961434134581}
+    linkText: Show Middle Value Reached Action
+    isActive: 1
+  linkedMaxReached:
+    linkedObject: {fileID: 3129851134823000013}
+    linkText: Show Maximum Value Reached Action
+    isActive: 1
   ValueChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -467,6 +483,7 @@ MonoBehaviour:
   eventOutputContainer: {fileID: 7344147712558315100}
   resetDriveOnSetup: 1
   resetDriveOnSetupFirstTimeOnly: 1
+  initialValueDriveSpeed: 5000
   targetValueReachedThreshold: 0.025
   emitEvents: 1
   joint: {fileID: 2051297999214337113}
@@ -610,6 +627,24 @@ Transform:
 --- !u!1 &7344147712558315100 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 7643514540901309464, guid: 28c785035c1675342b9e41fb684b7948,
+    type: 3}
+  m_PrefabInstance: {fileID: 1150828675843598916}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &4632773467267794737 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5742787135457963381, guid: 28c785035c1675342b9e41fb684b7948,
+    type: 3}
+  m_PrefabInstance: {fileID: 1150828675843598916}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &8635515961434134581 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8660163246180987505, guid: 28c785035c1675342b9e41fb684b7948,
+    type: 3}
+  m_PrefabInstance: {fileID: 1150828675843598916}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &3129851134823000013 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2636830725764533641, guid: 28c785035c1675342b9e41fb684b7948,
     type: 3}
   m_PrefabInstance: {fileID: 1150828675843598916}
   m_PrefabAsset: {fileID: 0}
@@ -812,16 +847,6 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6666400304308521552, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
-        type: 3}
-      propertyPath: consumerContainer
-      value: 
-      objectReference: {fileID: 4538608257460414173}
-    - target: {fileID: 6666400304308521552, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
-        type: 3}
-      propertyPath: consumerRigidbody
-      value: 
-      objectReference: {fileID: 835135679342871320}
     - target: {fileID: 3648960081298957348, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
         type: 3}
       propertyPath: primaryAction
@@ -832,6 +857,16 @@ PrefabInstance:
       propertyPath: secondaryAction
       value: 
       objectReference: {fileID: 5759501801176164688}
+    - target: {fileID: 6666400304308521552, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
+        type: 3}
+      propertyPath: consumerContainer
+      value: 
+      objectReference: {fileID: 4538608257460414173}
+    - target: {fileID: 6666400304308521552, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
+        type: 3}
+      propertyPath: consumerRigidbody
+      value: 
+      objectReference: {fileID: 835135679342871320}
     - target: {fileID: 8140612074155134679, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
         type: 3}
       propertyPath: ActiveAndEnabled.m_PersistentCalls.m_Calls.Array.data[0].m_Target
@@ -840,15 +875,21 @@ PrefabInstance:
     m_RemovedComponents:
     - {fileID: 8862883227734677280, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a, type: 3}
   m_SourcePrefab: {fileID: 100100000, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a, type: 3}
---- !u!4 &8190531345898926461 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5406743248307111831, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
-    type: 3}
-  m_PrefabInstance: {fileID: 4224940000398522090}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &5398302578280163270 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8090891674275893548, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
+    type: 3}
+  m_PrefabInstance: {fileID: 4224940000398522090}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &5856373121429202079 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7774344186399642229, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
+    type: 3}
+  m_PrefabInstance: {fileID: 4224940000398522090}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &8190531345898926461 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5406743248307111831, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
     type: 3}
   m_PrefabInstance: {fileID: 4224940000398522090}
   m_PrefabAsset: {fileID: 0}

--- a/Runtime/Prefabs/Transform/Interactions.AngularTransformDrive.prefab
+++ b/Runtime/Prefabs/Transform/Interactions.AngularTransformDrive.prefab
@@ -46,6 +46,22 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   drive: {fileID: 5969661976345957559}
+  linkedInteractableFacade:
+    linkedObject: {fileID: 2528702931149130789}
+    linkText: Show Interactable Facade Container
+    isActive: 1
+  linkedMinReached:
+    linkedObject: {fileID: 8106588416601379947}
+    linkText: Show Minimum Value Reached Action
+    isActive: 1
+  linkedMidReached:
+    linkedObject: {fileID: 5124267176743078767}
+    linkText: Show Middle Value Reached Action
+    isActive: 1
+  linkedMaxReached:
+    linkedObject: {fileID: 1992278634591827095}
+    linkText: Show Maximum Value Reached Action
+    isActive: 1
   ValueChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -549,18 +565,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 702caa48c730e92469a1c5144fd8ed46, type: 3}
---- !u!114 &9194919288075826165 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 7813340367162748559, guid: 702caa48c730e92469a1c5144fd8ed46,
-    type: 3}
-  m_PrefabInstance: {fileID: 1437886103419952506}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4ed154ebd688ecb47a6b727f72b24d8e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &2448744079595617656 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3607323991379943426, guid: 702caa48c730e92469a1c5144fd8ed46,
@@ -579,6 +583,18 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 1437886103419952506}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &9194919288075826165 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7813340367162748559, guid: 702caa48c730e92469a1c5144fd8ed46,
+    type: 3}
+  m_PrefabInstance: {fileID: 1437886103419952506}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4ed154ebd688ecb47a6b727f72b24d8e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &2584367644297197403
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -741,6 +757,24 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 4553730003580614942}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &8106588416601379947 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5742787135457963381, guid: 28c785035c1675342b9e41fb684b7948,
+    type: 3}
+  m_PrefabInstance: {fileID: 4553730003580614942}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &5124267176743078767 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8660163246180987505, guid: 28c785035c1675342b9e41fb684b7948,
+    type: 3}
+  m_PrefabInstance: {fileID: 4553730003580614942}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1992278634591827095 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2636830725764533641, guid: 28c785035c1675342b9e41fb684b7948,
+    type: 3}
+  m_PrefabInstance: {fileID: 4553730003580614942}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &6954216901078912301 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 6895096941427192883, guid: 28c785035c1675342b9e41fb684b7948,
@@ -866,24 +900,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a, type: 3}
---- !u!1 &6582222421973241952 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 1417232386877869616, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
-    type: 3}
-  m_PrefabInstance: {fileID: 5256762017038687824}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &4763570561051037854 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 785982709505707726, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
-    type: 3}
-  m_PrefabInstance: {fileID: 5256762017038687824}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2528702931149130789}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 906c6376972e44f469330df394172abd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!4 &4087960247752855420 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 8090891674275893548, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
@@ -902,3 +918,21 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 5256762017038687824}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &6582222421973241952 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1417232386877869616, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
+    type: 3}
+  m_PrefabInstance: {fileID: 5256762017038687824}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &4763570561051037854 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 785982709505707726, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
+    type: 3}
+  m_PrefabInstance: {fileID: 5256762017038687824}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2528702931149130789}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 906c6376972e44f469330df394172abd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Runtime/Prefabs/Transform/Interactions.LinearTransformDrive.prefab
+++ b/Runtime/Prefabs/Transform/Interactions.LinearTransformDrive.prefab
@@ -46,6 +46,22 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   drive: {fileID: 7040976076818030736}
+  linkedInteractableFacade:
+    linkedObject: {fileID: 743822601413769979}
+    linkText: Show Interactable Facade Container
+    isActive: 1
+  linkedMinReached:
+    linkedObject: {fileID: 4757261259178249507}
+    linkText: Show Minimum Value Reached Action
+    isActive: 1
+  linkedMidReached:
+    linkedObject: {fileID: 8473594196633670183}
+    linkText: Show Middle Value Reached Action
+    isActive: 1
+  linkedMaxReached:
+    linkedObject: {fileID: 2963564280943504863}
+    linkText: Show Maximum Value Reached Action
+    isActive: 1
   ValueChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -699,6 +715,7 @@ MonoBehaviour:
   eventOutputContainer: {fileID: 7468202290724158542}
   resetDriveOnSetup: 1
   resetDriveOnSetupFirstTimeOnly: 1
+  initialValueDriveSpeed: 5000
   targetValueReachedThreshold: 0.025
   emitEvents: 1
   interactable: {fileID: 7736847107121358400}
@@ -1002,9 +1019,27 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 988352720675774550}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &5910723491309409381 stripped
+--- !u!1 &7468202290724158542 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 7643514540901309464, guid: 28c785035c1675342b9e41fb684b7948,
+    type: 3}
+  m_PrefabInstance: {fileID: 988352720675774550}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &4757261259178249507 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5742787135457963381, guid: 28c785035c1675342b9e41fb684b7948,
+    type: 3}
+  m_PrefabInstance: {fileID: 988352720675774550}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &8473594196633670183 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8660163246180987505, guid: 28c785035c1675342b9e41fb684b7948,
+    type: 3}
+  m_PrefabInstance: {fileID: 988352720675774550}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &5118139266614037088 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 6895096941427192883, guid: 28c785035c1675342b9e41fb684b7948,
+  m_CorrespondingSourceObject: {fileID: 5381833560219560502, guid: 28c785035c1675342b9e41fb684b7948,
     type: 3}
   m_PrefabInstance: {fileID: 988352720675774550}
   m_PrefabAsset: {fileID: 0}
@@ -1014,9 +1049,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ead5b30fbf694c7408fc237b23268b0f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &5118139266614037088 stripped
+--- !u!114 &5910723491309409381 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5381833560219560502, guid: 28c785035c1675342b9e41fb684b7948,
+  m_CorrespondingSourceObject: {fileID: 6895096941427192883, guid: 28c785035c1675342b9e41fb684b7948,
     type: 3}
   m_PrefabInstance: {fileID: 988352720675774550}
   m_PrefabAsset: {fileID: 0}
@@ -1038,9 +1073,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ead5b30fbf694c7408fc237b23268b0f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &7468202290724158542 stripped
+--- !u!1 &2963564280943504863 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 7643514540901309464, guid: 28c785035c1675342b9e41fb684b7948,
+  m_CorrespondingSourceObject: {fileID: 2636830725764533641, guid: 28c785035c1675342b9e41fb684b7948,
     type: 3}
   m_PrefabInstance: {fileID: 988352720675774550}
   m_PrefabAsset: {fileID: 0}
@@ -1121,11 +1156,6 @@ PrefabInstance:
       propertyPath: isKinematicWhenInactive
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4534934962641631106, guid: 702caa48c730e92469a1c5144fd8ed46,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 3860205902975461033, guid: 702caa48c730e92469a1c5144fd8ed46,
         type: 3}
       propertyPath: Modified.m_PersistentCalls.m_Calls.Array.size
@@ -1155,6 +1185,11 @@ PrefabInstance:
         type: 3}
       propertyPath: Modified.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 4534934962641631106, guid: 702caa48c730e92469a1c5144fd8ed46,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4297763714491022842, guid: 702caa48c730e92469a1c5144fd8ed46,
         type: 3}
@@ -1193,6 +1228,18 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 702caa48c730e92469a1c5144fd8ed46, type: 3}
+--- !u!114 &6032950350965876142 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3607323991379943426, guid: 702caa48c730e92469a1c5144fd8ed46,
+    type: 3}
+  m_PrefabInstance: {fileID: 7040976075548100012}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa6b2e26d85a4f740b961ef57e412d92, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &5274295468376387719 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2919631799667094827, guid: 702caa48c730e92469a1c5144fd8ed46,
@@ -1211,18 +1258,6 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 7040976075548100012}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &6032950350965876142 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 3607323991379943426, guid: 702caa48c730e92469a1c5144fd8ed46,
-    type: 3}
-  m_PrefabInstance: {fileID: 7040976075548100012}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: aa6b2e26d85a4f740b961ef57e412d92, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &7040976076442826065
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1411,15 +1446,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 906c6376972e44f469330df394172abd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &1296488533182429602 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 8090891674275893548, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
-    type: 3}
-  m_PrefabInstance: {fileID: 7040976076819261582}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &743822601413769979 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 7774344186399642229, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
+    type: 3}
+  m_PrefabInstance: {fileID: 7040976076819261582}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1296488533182429602 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8090891674275893548, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
     type: 3}
   m_PrefabInstance: {fileID: 7040976076819261582}
   m_PrefabAsset: {fileID: 0}

--- a/Runtime/SharedResources/Scripts/Driver/DriveFacade.cs
+++ b/Runtime/SharedResources/Scripts/Driver/DriveFacade.cs
@@ -32,6 +32,30 @@
         [Serialized]
         [field: Header("Reference Settings"), DocumentedByXml, Restricted]
         public TDrive Drive { get; protected set; }
+        /// <summary>
+        /// The <see cref="GameObject"/> reference for the nested Interactable/>.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public ObjectReference LinkedInteractableFacade { get; protected set; }
+        /// <summary>
+        /// The <see cref="GameObject"/> reference for the nested minimum value reached event/>.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public ObjectReference LinkedMinReached { get; protected set; }
+        /// <summary>
+        /// The <see cref="GameObject"/> reference for the nested mid point value reached event/>.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public ObjectReference LinkedMidReached { get; protected set; }
+        /// <summary>
+        /// The <see cref="GameObject"/> reference for the nested max value reached event/>.
+        /// </summary>
+        [Serialized]
+        [field: DocumentedByXml]
+        public ObjectReference LinkedMaxReached { get; protected set; }
         #endregion
 
         #region Events


### PR DESCRIPTION
The new ObjectReference property type has been added to the DriveFacade
to highlight some common nested object references on the facade
inspector, making it easier to find some of the nested required prefabs
for easier customisation.