### PR TITLE
feat(Editor): add controllable creator window

### DIFF
--- a/Documentation/API/AngularDriver/AngularDriveTag.md
+++ b/Documentation/API/AngularDriver/AngularDriveTag.md
@@ -1,0 +1,16 @@
+# Class AngularDriveTag
+
+##### Inheritance
+
+* System.Object
+* AngularDriveTag
+
+###### **Namespace**: [Tilia.Interactions.Controllables.AngularDriver]
+
+##### Syntax
+
+```
+public class AngularDriveTag : MonoBehaviour
+```
+
+[Tilia.Interactions.Controllables.AngularDriver]: README.md

--- a/Documentation/API/AngularDriver/AngularDriveTag.md.meta
+++ b/Documentation/API/AngularDriver/AngularDriveTag.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 033d6c30aac3da743a4c940bc8332287
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/AngularDriver/README.md
+++ b/Documentation/API/AngularDriver/README.md
@@ -10,6 +10,8 @@ The basis to drive a control in a rotational angle.
 
 The public interface into any RotationalDrive prefab.
 
+#### [AngularDriveTag]
+
 #### [AngularJointDrive]
 
 A rotational drive that utilizes a physics joint to control the rotational angle.
@@ -20,5 +22,6 @@ A rotational drive that directly manipulates a Transform.rotation to control the
 
 [AngularDrive]: AngularDrive.md
 [AngularDriveFacade]: AngularDriveFacade.md
+[AngularDriveTag]: AngularDriveTag.md
 [AngularJointDrive]: AngularJointDrive.md
 [AngularTransformDrive]: AngularTransformDrive.md

--- a/Documentation/API/LinearDriver/LinearDriveTag.md
+++ b/Documentation/API/LinearDriver/LinearDriveTag.md
@@ -1,0 +1,16 @@
+# Class LinearDriveTag
+
+##### Inheritance
+
+* System.Object
+* LinearDriveTag
+
+###### **Namespace**: [Tilia.Interactions.Controllables.LinearDriver]
+
+##### Syntax
+
+```
+public class LinearDriveTag : MonoBehaviour
+```
+
+[Tilia.Interactions.Controllables.LinearDriver]: README.md

--- a/Documentation/API/LinearDriver/LinearDriveTag.md.meta
+++ b/Documentation/API/LinearDriver/LinearDriveTag.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d6a1e7b29fd906a46894b2716579a7d5
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Documentation/API/LinearDriver/README.md
+++ b/Documentation/API/LinearDriver/README.md
@@ -10,6 +10,8 @@ The basis to drive a control in a linear direction.
 
 The public interface into any Linear Drive prefab.
 
+#### [LinearDriveTag]
+
 #### [LinearJointDrive]
 
 A directional drive that utilizes a physics joint to control the linear translation movement.
@@ -20,5 +22,6 @@ A directional drive that manipulates a Transform.position to control the linear 
 
 [LinearDrive]: LinearDrive.md
 [LinearDriveFacade]: LinearDriveFacade.md
+[LinearDriveTag]: LinearDriveTag.md
 [LinearJointDrive]: LinearJointDrive.md
 [LinearTransformDrive]: LinearTransformDrive.md

--- a/Editor/Interactables.meta
+++ b/Editor/Interactables.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 11240069231242b44a96d14b662ff71e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Interactables/ControllableCreatorEditorWindow.cs
+++ b/Editor/Interactables/ControllableCreatorEditorWindow.cs
@@ -1,0 +1,133 @@
+﻿namespace Tilia.Interactions.Controllables.Interactables
+{
+    using Tilia.Interactions.Controllables.AngularDriver;
+    using Tilia.Interactions.Controllables.LinearDriver;
+    using Tilia.Interactions.Interactables.Interactables;
+    using UnityEditor;
+    using UnityEngine;
+
+    [InitializeOnLoad]
+    public class ControllableCreatorEditorWindow : EditorWindow
+    {
+        private const string windowTitle = "Controllable Creator";
+        private const string angularJointAsset = "Interactions.AngularJointDrive";
+        private const string linearJointAsset = "Interactions.LinearJointDrive";
+        private const string angularTransformAsset = "Interactions.AngularTransformDrive";
+        private const string linearTransformAsset = "Interactions.LinearTransformDrive";
+        private const string assetSuffix = ".prefab";
+        private static EditorWindow promptWindow;
+        private Vector2 scrollPosition;
+        private GameObject angularJointPrefab;
+        private GameObject linearJointPrefab;
+        private GameObject angularTransformPrefab;
+        private GameObject linearTransformPrefab;
+        private string[] prefabTypes = new string[]
+        {
+            "Linear Joint Drive",
+            "Linear Transform Drive",
+            "Angular Joint Drive",
+            "Angular Transform Drive"
+        };
+        private int prefabTypeIndex = 0;
+
+        public void OnGUI()
+        {
+            using (GUILayout.ScrollViewScope scrollViewScope = new GUILayout.ScrollViewScope(scrollPosition))
+            {
+                scrollPosition = scrollViewScope.scrollPosition;
+                GUILayout.Label("Controllable Creator", EditorStyles.boldLabel);
+
+                prefabTypeIndex = EditorGUILayout.Popup(prefabTypeIndex, prefabTypes);
+
+                if (GUILayout.Button("Convert"))
+                {
+                    switch (prefabTypeIndex)
+                    {
+                        case 0:
+                            ProcessSelectedGameObjects<LinearJointDrive>(linearJointPrefab);
+                            break;
+                        case 1:
+                            ProcessSelectedGameObjects<LinearTransformDrive>(linearTransformPrefab);
+                            break;
+                        case 2:
+                            ProcessSelectedGameObjects<AngularJointDrive>(angularJointPrefab);
+                            break;
+                        case 3:
+                            ProcessSelectedGameObjects<AngularTransformDrive>(angularTransformPrefab);
+                            break;
+                    }
+
+                }
+            }
+        }
+
+        protected virtual void OnEnable()
+        {
+            SetAsset(angularJointAsset, ref angularJointPrefab);
+            SetAsset(linearJointAsset, ref linearJointPrefab);
+            SetAsset(angularTransformAsset, ref angularTransformPrefab);
+            SetAsset(linearTransformAsset, ref linearTransformPrefab);
+        }
+
+        protected virtual void SetAsset(string assetName, ref GameObject prefab)
+        {
+            foreach (string assetGUID in AssetDatabase.FindAssets(assetName))
+            {
+                string assetPath = AssetDatabase.GUIDToAssetPath(assetGUID);
+                if (assetPath.Contains(assetName + assetSuffix))
+                {
+                    prefab = AssetDatabase.LoadAssetAtPath<GameObject>(assetPath);
+                }
+            }
+        }
+
+        protected virtual void ProcessSelectedGameObjects<DriveType>(GameObject prefabToUse)
+        {
+            foreach (Transform selectedTransform in Selection.transforms)
+            {
+                ConvertSelectedGameObject<DriveType>(selectedTransform.gameObject, prefabToUse);
+            }
+        }
+
+        protected virtual void ConvertSelectedGameObject<DriveType>(GameObject objectToConvert, GameObject prefabToUse)
+        {
+            DriveType interactable = objectToConvert.GetComponentInParent<DriveType>();
+            if (interactable == null)
+            {
+                CreateInteractable(objectToConvert, prefabToUse);
+            }
+        }
+
+        protected virtual void CreateInteractable(GameObject objectToWrap, GameObject prefabToUse)
+        {
+            int siblingIndex = objectToWrap.transform.GetSiblingIndex();
+            GameObject newInteractable = (GameObject)PrefabUtility.InstantiatePrefab(prefabToUse);
+            newInteractable.name += "_" + objectToWrap.name;
+            InteractableFacade facade = newInteractable.GetComponentInChildren<InteractableFacade>();
+
+            newInteractable.transform.SetParent(objectToWrap.transform.parent);
+            newInteractable.transform.localPosition = objectToWrap.transform.localPosition;
+            newInteractable.transform.localRotation = objectToWrap.transform.localRotation;
+            newInteractable.transform.localScale = objectToWrap.transform.localScale;
+
+            foreach (MeshRenderer defaultMeshes in facade.Configuration.MeshContainer.GetComponentsInChildren<MeshRenderer>())
+            {
+                defaultMeshes.gameObject.SetActive(false);
+            }
+
+            objectToWrap.transform.SetParent(facade.Configuration.MeshContainer.transform);
+            objectToWrap.transform.localPosition = Vector3.zero;
+            objectToWrap.transform.localRotation = Quaternion.identity;
+            objectToWrap.transform.localScale = Vector3.one;
+
+            newInteractable.transform.SetSiblingIndex(siblingIndex);
+        }
+
+        [MenuItem("Window/Tilia/Interactions/" + windowTitle)]
+        private static void ShowWindow()
+        {
+            promptWindow = EditorWindow.GetWindow(typeof(ControllableCreatorEditorWindow));
+            promptWindow.titleContent = new GUIContent(windowTitle);
+        }
+    }
+}

--- a/Editor/Interactables/ControllableCreatorEditorWindow.cs.meta
+++ b/Editor/Interactables/ControllableCreatorEditorWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 804e0e3a24517ab47b00fb72f6cf2bf3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Tilia.Interactions.Controllables.Unity.Editor.asmdef
+++ b/Editor/Tilia.Interactions.Controllables.Unity.Editor.asmdef
@@ -1,8 +1,11 @@
 {
     "name": "Tilia.Interactions.Controllables.Unity.Editor",
     "references": [
-        "Zinnia.Editor"
+        "Zinnia.Editor",
+        "Tilia.Interactions.Controllables.Unity.Runtime",
+        "Tilia.Interactions.Interactables.Unity.Runtime"
     ],
+    "optionalUnityReferences": [],
     "includePlatforms": [
         "Editor"
     ],
@@ -11,7 +14,5 @@
     "overrideReferences": true,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": [],
-    "versionDefines": [],
-    "noEngineReferences": false
+    "defineConstraints": []
 }


### PR DESCRIPTION
The new Controllable Creator window makes it easier to turn an existing
scene mesh into a controllable by automatically adding the selected
prefab and nesting the mesh in the appropriate location.