### PR TITLE
fix(Editor): only apply position when auto creating controllable

### DIFF
--- a/Editor/Interactables/ControllableCreatorEditorWindow.cs
+++ b/Editor/Interactables/ControllableCreatorEditorWindow.cs
@@ -107,8 +107,6 @@
 
             newInteractable.transform.SetParent(objectToWrap.transform.parent);
             newInteractable.transform.localPosition = objectToWrap.transform.localPosition;
-            newInteractable.transform.localRotation = objectToWrap.transform.localRotation;
-            newInteractable.transform.localScale = objectToWrap.transform.localScale;
 
             foreach (MeshRenderer defaultMeshes in facade.Configuration.MeshContainer.GetComponentsInChildren<MeshRenderer>())
             {
@@ -117,8 +115,6 @@
 
             objectToWrap.transform.SetParent(facade.Configuration.MeshContainer.transform);
             objectToWrap.transform.localPosition = Vector3.zero;
-            objectToWrap.transform.localRotation = Quaternion.identity;
-            objectToWrap.transform.localScale = Vector3.one;
 
             newInteractable.transform.SetSiblingIndex(siblingIndex);
         }


### PR DESCRIPTION
The Controllable Creator now only applies the original mesh position
to the new controllable prefab and the rotation, scale of the mesh
stay on the original mesh. This is because controllables that have
external rotations and scales will warp the object inside so the
mesh is the thing that needs rotating and scaling.