### PR TITLE
fix(Drive): compare with the target value threshold correctly

### DIFF
--- a/Runtime/SharedResources/Scripts/AngularDriver/AngularDrive.cs
+++ b/Runtime/SharedResources/Scripts/AngularDriver/AngularDrive.cs
@@ -155,7 +155,8 @@
         protected virtual float CalculateDirectionMultiplier()
         {
             float actualAngle = ActualTargetAngle;
-            if (actualAngle.ApproxEquals(currentPseudoRotation, TargetValueReachedThreshold))
+            float thresholdRotation = (DriveLimits.maximum - DriveLimits.minimum) * TargetValueReachedThreshold;
+            if (actualAngle.ApproxEquals(currentPseudoRotation, thresholdRotation))
             {
                 return 0f;
             }
@@ -177,12 +178,13 @@
         /// <returns>Whether the limits have been applied.</returns>
         protected virtual bool ApplyLimits()
         {
-            if (currentPseudoRotation < DriveLimits.minimum - TargetValueReachedThreshold)
+            float thresholdRotation = (DriveLimits.maximum - DriveLimits.minimum) * TargetValueReachedThreshold;
+            if (currentPseudoRotation < DriveLimits.minimum - thresholdRotation)
             {
                 GetDriveTransform().localRotation = Quaternion.Euler(-AxisDirection * DriveLimits.minimum);
                 return true;
             }
-            else if (currentPseudoRotation > DriveLimits.maximum + TargetValueReachedThreshold)
+            else if (currentPseudoRotation > DriveLimits.maximum + thresholdRotation)
             {
                 GetDriveTransform().localRotation = Quaternion.Euler(-AxisDirection * DriveLimits.maximum);
                 return true;
@@ -197,7 +199,8 @@
         /// <returns>The velocity to drive the control automatically with.</returns>
         protected virtual float CalculateAutoDriveVelocity()
         {
-            return (Facade.MoveToTargetValue && !currentPseudoRotation.ApproxEquals(ActualTargetAngle, TargetValueReachedThreshold) ? Facade.DriveSpeed : 0f) * CalculateDirectionMultiplier();
+            float thresholdRotation = (DriveLimits.maximum - DriveLimits.minimum) * TargetValueReachedThreshold;
+            return (Facade.MoveToTargetValue && !currentPseudoRotation.ApproxEquals(ActualTargetAngle, thresholdRotation) ? Facade.DriveSpeed : 0f) * CalculateDirectionMultiplier();
         }
 
         /// <summary>

--- a/Runtime/SharedResources/Scripts/AngularDriver/AngularDrive.cs
+++ b/Runtime/SharedResources/Scripts/AngularDriver/AngularDrive.cs
@@ -23,6 +23,10 @@
         /// The target angle for the control to reach.
         /// </summary>
         protected float ActualTargetAngle => Mathf.Lerp(DriveLimits.minimum, DriveLimits.maximum, Facade.TargetValue);
+        /// <summary>
+        /// The threshold angle within which the target value is reached.
+        /// </summary>
+        protected float ThresholdAngle => (DriveLimits.maximum - DriveLimits.minimum) * TargetValueReachedThreshold;
 
         /// <summary>
         /// The total number of degrees in a circle.
@@ -155,8 +159,7 @@
         protected virtual float CalculateDirectionMultiplier()
         {
             float actualAngle = ActualTargetAngle;
-            float thresholdRotation = (DriveLimits.maximum - DriveLimits.minimum) * TargetValueReachedThreshold;
-            if (actualAngle.ApproxEquals(currentPseudoRotation, thresholdRotation))
+            if (actualAngle.ApproxEquals(currentPseudoRotation, ThresholdAngle))
             {
                 return 0f;
             }
@@ -178,13 +181,13 @@
         /// <returns>Whether the limits have been applied.</returns>
         protected virtual bool ApplyLimits()
         {
-            float thresholdRotation = (DriveLimits.maximum - DriveLimits.minimum) * TargetValueReachedThreshold;
-            if (currentPseudoRotation < DriveLimits.minimum - thresholdRotation)
+            float thresholdAngle = ThresholdAngle;
+            if (currentPseudoRotation < DriveLimits.minimum - thresholdAngle)
             {
                 GetDriveTransform().localRotation = Quaternion.Euler(-AxisDirection * DriveLimits.minimum);
                 return true;
             }
-            else if (currentPseudoRotation > DriveLimits.maximum + thresholdRotation)
+            else if (currentPseudoRotation > DriveLimits.maximum + thresholdAngle)
             {
                 GetDriveTransform().localRotation = Quaternion.Euler(-AxisDirection * DriveLimits.maximum);
                 return true;
@@ -199,8 +202,7 @@
         /// <returns>The velocity to drive the control automatically with.</returns>
         protected virtual float CalculateAutoDriveVelocity()
         {
-            float thresholdRotation = (DriveLimits.maximum - DriveLimits.minimum) * TargetValueReachedThreshold;
-            return (Facade.MoveToTargetValue && !currentPseudoRotation.ApproxEquals(ActualTargetAngle, thresholdRotation) ? Facade.DriveSpeed : 0f) * CalculateDirectionMultiplier();
+            return (Facade.MoveToTargetValue && !currentPseudoRotation.ApproxEquals(ActualTargetAngle, ThresholdAngle) ? Facade.DriveSpeed : 0f) * CalculateDirectionMultiplier();
         }
 
         /// <summary>


### PR DESCRIPTION
There was an issue where the AngularDrive treated the target value
threshold as actual degrees when compare with current pseudo rotation.
Instead, it should treat the target value threshold as normalized value.

This fix works out the equivalent threshold in degrees because this
usually results in a larger floating point value for stability.