### PR TITLE
fix(Documentation): add missing API docs

### DIFF
--- a/Documentation/API/AngularDriver/AngularDrive.md
+++ b/Documentation/API/AngularDriver/AngularDrive.md
@@ -61,6 +61,10 @@ IProcessable
 
 [Drive<AngularDriveFacade, AngularDrive>.SnapToStepContainer]
 
+[Drive<AngularDriveFacade, AngularDrive>.GrabbedDragEmitter]
+
+[Drive<AngularDriveFacade, AngularDrive>.UngrabbedDragEmitter]
+
 [Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetup]
 
 [Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetupFirstTimeOnly]
@@ -114,6 +118,10 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.SetDriveLimits()]
 
 [Drive<AngularDriveFacade, AngularDrive>.SetAxisDirection()]
+
+[Drive<AngularDriveFacade, AngularDrive>.SetGrabbedDrag(Single)]
+
+[Drive<AngularDriveFacade, AngularDrive>.SetUngrabbedDrag(Single)]
 
 [Drive<AngularDriveFacade, AngularDrive>.ProcessDriveSpeed(Single, Boolean)]
 
@@ -557,6 +565,8 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.Facade]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Facade
 [Drive<AngularDriveFacade, AngularDrive>.EventOutputContainer]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EventOutputContainer
 [Drive<AngularDriveFacade, AngularDrive>.SnapToStepContainer]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SnapToStepContainer
+[Drive<AngularDriveFacade, AngularDrive>.GrabbedDragEmitter]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GrabbedDragEmitter
+[Drive<AngularDriveFacade, AngularDrive>.UngrabbedDragEmitter]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_UngrabbedDragEmitter
 [Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetup]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetup
 [Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetupFirstTimeOnly]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetupFirstTimeOnly
 [Drive<AngularDriveFacade, AngularDrive>.InitialValueDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_InitialValueDriveSpeed
@@ -584,6 +594,8 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.ToggleSnapToStepLogic(Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ToggleSnapToStepLogic_System_Boolean_
 [Drive<AngularDriveFacade, AngularDrive>.SetDriveLimits()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetDriveLimits
 [Drive<AngularDriveFacade, AngularDrive>.SetAxisDirection()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetAxisDirection
+[Drive<AngularDriveFacade, AngularDrive>.SetGrabbedDrag(Single)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetGrabbedDrag_System_Single_
+[Drive<AngularDriveFacade, AngularDrive>.SetUngrabbedDrag(Single)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetUngrabbedDrag_System_Single_
 [Drive<AngularDriveFacade, AngularDrive>.ProcessDriveSpeed(Single, Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ProcessDriveSpeed_System_Single_System_Boolean_
 [Drive<AngularDriveFacade, AngularDrive>.SetTargetValue(Single)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetTargetValue_System_Single_
 [Drive<AngularDriveFacade, AngularDrive>.CalculateDriveAxis(DriveAxis.Axis)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateDriveAxis_Tilia_Interactions_Controllables_Driver_DriveAxis_Axis_

--- a/Documentation/API/AngularDriver/AngularDriveFacade.md
+++ b/Documentation/API/AngularDriver/AngularDriveFacade.md
@@ -60,6 +60,10 @@ The public interface into any RotationalDrive prefab.
 
 [DriveFacade<AngularDrive, AngularDriveFacade>.DriveSpeed]
 
+[DriveFacade<AngularDrive, AngularDriveFacade>.UngrabbedDrag]
+
+[DriveFacade<AngularDrive, AngularDriveFacade>.GrabbedDrag]
+
 [DriveFacade<AngularDrive, AngularDriveFacade>.StartAtInitialTargetValue]
 
 [DriveFacade<AngularDrive, AngularDriveFacade>.InitialTargetValue]
@@ -107,6 +111,10 @@ The public interface into any RotationalDrive prefab.
 [DriveFacade<AngularDrive, AngularDriveFacade>.OnAfterStepIncrementChange()]
 
 [DriveFacade<AngularDrive, AngularDriveFacade>.OnAfterSnapToStepOnRelease()]
+
+[DriveFacade<AngularDrive, AngularDriveFacade>.OnAfterUngrabbedDragChange()]
+
+[DriveFacade<AngularDrive, AngularDriveFacade>.OnAfterGrabbedDragChange()]
 
 ##### Namespace
 
@@ -287,6 +295,8 @@ public virtual void SetHingeLocationZ(float value)
 [DriveFacade<AngularDrive, AngularDriveFacade>.StoppedMoving]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_StoppedMoving
 [DriveFacade<AngularDrive, AngularDriveFacade>.DriveAxis]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_DriveAxis
 [DriveFacade<AngularDrive, AngularDriveFacade>.DriveSpeed]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_DriveSpeed
+[DriveFacade<AngularDrive, AngularDriveFacade>.UngrabbedDrag]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_UngrabbedDrag
+[DriveFacade<AngularDrive, AngularDriveFacade>.GrabbedDrag]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_GrabbedDrag
 [DriveFacade<AngularDrive, AngularDriveFacade>.StartAtInitialTargetValue]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_StartAtInitialTargetValue
 [DriveFacade<AngularDrive, AngularDriveFacade>.InitialTargetValue]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_InitialTargetValue
 [DriveFacade<AngularDrive, AngularDriveFacade>.MoveToTargetValue]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_MoveToTargetValue
@@ -311,6 +321,8 @@ public virtual void SetHingeLocationZ(float value)
 [DriveFacade<AngularDrive, AngularDriveFacade>.OnAfterStepRangeChange()]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_OnAfterStepRangeChange
 [DriveFacade<AngularDrive, AngularDriveFacade>.OnAfterStepIncrementChange()]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_OnAfterStepIncrementChange
 [DriveFacade<AngularDrive, AngularDriveFacade>.OnAfterSnapToStepOnRelease()]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_OnAfterSnapToStepOnRelease
+[DriveFacade<AngularDrive, AngularDriveFacade>.OnAfterUngrabbedDragChange()]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_OnAfterUngrabbedDragChange
+[DriveFacade<AngularDrive, AngularDriveFacade>.OnAfterGrabbedDragChange()]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_OnAfterGrabbedDragChange
 [Tilia.Interactions.Controllables.AngularDriver]: README.md
 [DriveLimit]: AngularDriveFacade.md#DriveLimit
 [HingeLocation]: AngularDriveFacade.md#HingeLocation

--- a/Documentation/API/AngularDriver/AngularJointDrive.md
+++ b/Documentation/API/AngularDriver/AngularJointDrive.md
@@ -92,6 +92,10 @@ IProcessable
 
 [Drive<AngularDriveFacade, AngularDrive>.SnapToStepContainer]
 
+[Drive<AngularDriveFacade, AngularDrive>.GrabbedDragEmitter]
+
+[Drive<AngularDriveFacade, AngularDrive>.UngrabbedDragEmitter]
+
 [Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetup]
 
 [Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetupFirstTimeOnly]
@@ -145,6 +149,10 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.SetDriveLimits()]
 
 [Drive<AngularDriveFacade, AngularDrive>.SetAxisDirection()]
+
+[Drive<AngularDriveFacade, AngularDrive>.SetGrabbedDrag(Single)]
+
+[Drive<AngularDriveFacade, AngularDrive>.SetUngrabbedDrag(Single)]
 
 [Drive<AngularDriveFacade, AngularDrive>.ProcessDriveSpeed(Single, Boolean)]
 
@@ -476,6 +484,8 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.Facade]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Facade
 [Drive<AngularDriveFacade, AngularDrive>.EventOutputContainer]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EventOutputContainer
 [Drive<AngularDriveFacade, AngularDrive>.SnapToStepContainer]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SnapToStepContainer
+[Drive<AngularDriveFacade, AngularDrive>.GrabbedDragEmitter]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GrabbedDragEmitter
+[Drive<AngularDriveFacade, AngularDrive>.UngrabbedDragEmitter]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_UngrabbedDragEmitter
 [Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetup]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetup
 [Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetupFirstTimeOnly]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetupFirstTimeOnly
 [Drive<AngularDriveFacade, AngularDrive>.InitialValueDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_InitialValueDriveSpeed
@@ -503,6 +513,8 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.ToggleSnapToStepLogic(Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ToggleSnapToStepLogic_System_Boolean_
 [Drive<AngularDriveFacade, AngularDrive>.SetDriveLimits()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetDriveLimits
 [Drive<AngularDriveFacade, AngularDrive>.SetAxisDirection()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetAxisDirection
+[Drive<AngularDriveFacade, AngularDrive>.SetGrabbedDrag(Single)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetGrabbedDrag_System_Single_
+[Drive<AngularDriveFacade, AngularDrive>.SetUngrabbedDrag(Single)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetUngrabbedDrag_System_Single_
 [Drive<AngularDriveFacade, AngularDrive>.ProcessDriveSpeed(Single, Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ProcessDriveSpeed_System_Single_System_Boolean_
 [Drive<AngularDriveFacade, AngularDrive>.SetTargetValue(Single)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetTargetValue_System_Single_
 [Drive<AngularDriveFacade, AngularDrive>.CalculateDriveAxis(DriveAxis.Axis)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateDriveAxis_Tilia_Interactions_Controllables_Driver_DriveAxis_Axis_

--- a/Documentation/API/AngularDriver/AngularTransformDrive.md
+++ b/Documentation/API/AngularDriver/AngularTransformDrive.md
@@ -89,6 +89,10 @@ IProcessable
 
 [Drive<AngularDriveFacade, AngularDrive>.SnapToStepContainer]
 
+[Drive<AngularDriveFacade, AngularDrive>.GrabbedDragEmitter]
+
+[Drive<AngularDriveFacade, AngularDrive>.UngrabbedDragEmitter]
+
 [Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetup]
 
 [Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetupFirstTimeOnly]
@@ -142,6 +146,10 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.SetDriveLimits()]
 
 [Drive<AngularDriveFacade, AngularDrive>.SetAxisDirection()]
+
+[Drive<AngularDriveFacade, AngularDrive>.SetGrabbedDrag(Single)]
+
+[Drive<AngularDriveFacade, AngularDrive>.SetUngrabbedDrag(Single)]
 
 [Drive<AngularDriveFacade, AngularDrive>.ProcessDriveSpeed(Single, Boolean)]
 
@@ -418,6 +426,8 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.Facade]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Facade
 [Drive<AngularDriveFacade, AngularDrive>.EventOutputContainer]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EventOutputContainer
 [Drive<AngularDriveFacade, AngularDrive>.SnapToStepContainer]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SnapToStepContainer
+[Drive<AngularDriveFacade, AngularDrive>.GrabbedDragEmitter]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GrabbedDragEmitter
+[Drive<AngularDriveFacade, AngularDrive>.UngrabbedDragEmitter]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_UngrabbedDragEmitter
 [Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetup]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetup
 [Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetupFirstTimeOnly]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetupFirstTimeOnly
 [Drive<AngularDriveFacade, AngularDrive>.InitialValueDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_InitialValueDriveSpeed
@@ -445,6 +455,8 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.ToggleSnapToStepLogic(Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ToggleSnapToStepLogic_System_Boolean_
 [Drive<AngularDriveFacade, AngularDrive>.SetDriveLimits()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetDriveLimits
 [Drive<AngularDriveFacade, AngularDrive>.SetAxisDirection()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetAxisDirection
+[Drive<AngularDriveFacade, AngularDrive>.SetGrabbedDrag(Single)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetGrabbedDrag_System_Single_
+[Drive<AngularDriveFacade, AngularDrive>.SetUngrabbedDrag(Single)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetUngrabbedDrag_System_Single_
 [Drive<AngularDriveFacade, AngularDrive>.ProcessDriveSpeed(Single, Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ProcessDriveSpeed_System_Single_System_Boolean_
 [Drive<AngularDriveFacade, AngularDrive>.SetTargetValue(Single)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetTargetValue_System_Single_
 [Drive<AngularDriveFacade, AngularDrive>.CalculateDriveAxis(DriveAxis.Axis)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateDriveAxis_Tilia_Interactions_Controllables_Driver_DriveAxis_Axis_

--- a/Documentation/API/Driver/Drive-2.md
+++ b/Documentation/API/Driver/Drive-2.md
@@ -24,6 +24,7 @@ The basis for a mechanism to drive motion on a control.
   * [EmitEvents]
   * [EventOutputContainer]
   * [Facade]
+  * [GrabbedDragEmitter]
   * [InitialValueDriveSpeed]
   * [NormalizedStepValue]
   * [NormalizedValue]
@@ -32,6 +33,7 @@ The basis for a mechanism to drive motion on a control.
   * [SnapToStepContainer]
   * [StepValue]
   * [TargetValueReachedThreshold]
+  * [UngrabbedDragEmitter]
   * [Value]
 * [Methods]
   * [CalculateDriveAxis(DriveAxis.Axis)]
@@ -61,7 +63,9 @@ The basis for a mechanism to drive motion on a control.
   * [SetAxisDirection()]
   * [SetDriveLimits()]
   * [SetDriveTargetValue(Vector3)]
+  * [SetGrabbedDrag(Single)]
   * [SetTargetValue(Single)]
+  * [SetUngrabbedDrag(Single)]
   * [SetUp()]
   * [SetUpInternals()]
   * [StartMoving()]
@@ -253,6 +257,16 @@ The public interface facade.
 public TFacade Facade { get; protected set; }
 ```
 
+#### GrabbedDragEmitter
+
+The Float Emitter for handling grabbed drag.
+
+##### Declaration
+
+```
+public FloatEventProxyEmitter GrabbedDragEmitter { get; protected set; }
+```
+
 #### InitialValueDriveSpeed
 
 The value to set the drive speed to when driving the control to the initial start value.
@@ -331,6 +345,16 @@ The threshold that the current normalized value of the control can be within to 
 
 ```
 public float TargetValueReachedThreshold { get; set; }
+```
+
+#### UngrabbedDragEmitter
+
+The Float Emitter for handling ungrabbed drag.
+
+##### Declaration
+
+```
+public FloatEventProxyEmitter UngrabbedDragEmitter { get; protected set; }
 ```
 
 #### Value
@@ -697,6 +721,22 @@ protected virtual void SetDriveTargetValue(Vector3 targetValue)
 | --- | --- | --- |
 | Vector3 | targetValue | The value to set the drive target to. |
 
+#### SetGrabbedDrag(Single)
+
+Sets the grabbed drag value.
+
+##### Declaration
+
+```
+public virtual void SetGrabbedDrag(float value)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | value | The drag value. |
+
 #### SetTargetValue(Single)
 
 Sets the target value of the drive to the given normalized value.
@@ -712,6 +752,22 @@ public virtual void SetTargetValue(float normalizedValue)
 | Type | Name | Description |
 | --- | --- | --- |
 | System.Single | normalizedValue | The normalized value to set the Target Value to. |
+
+#### SetUngrabbedDrag(Single)
+
+Sets the ungrabbed drag value.
+
+##### Declaration
+
+```
+public virtual void SetUngrabbedDrag(float value)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| System.Single | value | The drag value. |
 
 #### SetUp()
 
@@ -809,6 +865,7 @@ IProcessable
 [EmitEvents]: #EmitEvents
 [EventOutputContainer]: #EventOutputContainer
 [Facade]: #Facade
+[GrabbedDragEmitter]: #GrabbedDragEmitter
 [InitialValueDriveSpeed]: #InitialValueDriveSpeed
 [NormalizedStepValue]: #NormalizedStepValue
 [NormalizedValue]: #NormalizedValue
@@ -817,6 +874,7 @@ IProcessable
 [SnapToStepContainer]: #SnapToStepContainer
 [StepValue]: #StepValue
 [TargetValueReachedThreshold]: #TargetValueReachedThreshold
+[UngrabbedDragEmitter]: #UngrabbedDragEmitter
 [Value]: #Value
 [Methods]: #Methods
 [CalculateDriveAxis(DriveAxis.Axis)]: #CalculateDriveAxisDriveAxis.Axis
@@ -846,7 +904,9 @@ IProcessable
 [SetAxisDirection()]: #SetAxisDirection
 [SetDriveLimits()]: #SetDriveLimits
 [SetDriveTargetValue(Vector3)]: #SetDriveTargetValueVector3
+[SetGrabbedDrag(Single)]: #SetGrabbedDragSingle
 [SetTargetValue(Single)]: #SetTargetValueSingle
+[SetUngrabbedDrag(Single)]: #SetUngrabbedDragSingle
 [SetUp()]: #SetUp
 [SetUpInternals()]: #SetUpInternals
 [StartMoving()]: #StartMoving

--- a/Documentation/API/Driver/DriveFacade-2.md
+++ b/Documentation/API/Driver/DriveFacade-2.md
@@ -19,6 +19,7 @@ The basis of the public interface that will drive a control in relation to a spe
   * [Drive]
   * [DriveAxis]
   * [DriveSpeed]
+  * [GrabbedDrag]
   * [InitialTargetValue]
   * [LinkedInteractableFacade]
   * [LinkedMaxReached]
@@ -30,16 +31,19 @@ The basis of the public interface that will drive a control in relation to a spe
   * [StepIncrement]
   * [StepRange]
   * [TargetValue]
+  * [UngrabbedDrag]
 * [Methods]
   * [CalculateDriveAxis(DriveAxis.Axis)]
   * [ForceSnapToStepValue(Single)]
   * [OnAfterDriveAxisChange()]
   * [OnAfterDriveSpeedChange()]
+  * [OnAfterGrabbedDragChange()]
   * [OnAfterMoveToTargetValueChange()]
   * [OnAfterSnapToStepOnRelease()]
   * [OnAfterStepIncrementChange()]
   * [OnAfterStepRangeChange()]
   * [OnAfterTargetValueChange()]
+  * [OnAfterUngrabbedDragChange()]
   * [ProcessAutoDrive(Boolean)]
   * [ProcessDriveSpeed(Single, Boolean)]
   * [SetDriveAxis(Int32)]
@@ -179,6 +183,16 @@ The speed in which the drive will attempt to move the control to the desired val
 public float DriveSpeed { get; set; }
 ```
 
+#### GrabbedDrag
+
+The drag to apply when the control is grabbed.
+
+##### Declaration
+
+```
+public float GrabbedDrag { get; set; }
+```
+
 #### InitialTargetValue
 
 The normalized value to attempt to drive the control to when it is first enabled.
@@ -289,6 +303,16 @@ The normalized value to attempt to drive the control to if the [MoveToTargetValu
 public float TargetValue { get; set; }
 ```
 
+#### UngrabbedDrag
+
+The drag to apply when the control is ungrabbed.
+
+##### Declaration
+
+```
+public float UngrabbedDrag { get; set; }
+```
+
 ### Methods
 
 #### CalculateDriveAxis(DriveAxis.Axis)
@@ -343,6 +367,16 @@ Called after [DriveSpeed] has been changed.
 protected virtual void OnAfterDriveSpeedChange()
 ```
 
+#### OnAfterGrabbedDragChange()
+
+Called after [GrabbedDrag] has been changed.
+
+##### Declaration
+
+```
+protected virtual void OnAfterGrabbedDragChange()
+```
+
 #### OnAfterMoveToTargetValueChange()
 
 Called after [MoveToTargetValue] has been changed.
@@ -391,6 +425,16 @@ Called after [TargetValue] has been changed.
 
 ```
 protected virtual void OnAfterTargetValueChange()
+```
+
+#### OnAfterUngrabbedDragChange()
+
+Called after [UngrabbedDrag] has been changed.
+
+##### Declaration
+
+```
+protected virtual void OnAfterUngrabbedDragChange()
 ```
 
 #### ProcessAutoDrive(Boolean)
@@ -528,11 +572,13 @@ public virtual void SetTargetValueByStepValue(float stepValue)
 [MoveToTargetValue]: DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_MoveToTargetValue
 [DriveAxis]: DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_DriveAxis
 [DriveSpeed]: DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_DriveSpeed
+[GrabbedDrag]: DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_GrabbedDrag
 [MoveToTargetValue]: DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_MoveToTargetValue
 [SnapToStepOnRelease]: DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_SnapToStepOnRelease
 [StepIncrement]: DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_StepIncrement
 [StepRange]: DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_StepRange
 [TargetValue]: DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_TargetValue
+[UngrabbedDrag]: DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_UngrabbedDrag
 [DriveSpeed]: DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_DriveSpeed
 [DriveAxis]: DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_DriveAxis
 [DriveAxis.Axis]: DriveAxis.Axis.md
@@ -556,6 +602,7 @@ public virtual void SetTargetValueByStepValue(float stepValue)
 [Drive]: #Drive
 [DriveAxis]: #DriveAxis
 [DriveSpeed]: #DriveSpeed
+[GrabbedDrag]: #GrabbedDrag
 [InitialTargetValue]: #InitialTargetValue
 [LinkedInteractableFacade]: #LinkedInteractableFacade
 [LinkedMaxReached]: #LinkedMaxReached
@@ -567,16 +614,19 @@ public virtual void SetTargetValueByStepValue(float stepValue)
 [StepIncrement]: #StepIncrement
 [StepRange]: #StepRange
 [TargetValue]: #TargetValue
+[UngrabbedDrag]: #UngrabbedDrag
 [Methods]: #Methods
 [CalculateDriveAxis(DriveAxis.Axis)]: #CalculateDriveAxisDriveAxis.Axis
 [ForceSnapToStepValue(Single)]: #ForceSnapToStepValueSingle
 [OnAfterDriveAxisChange()]: #OnAfterDriveAxisChange
 [OnAfterDriveSpeedChange()]: #OnAfterDriveSpeedChange
+[OnAfterGrabbedDragChange()]: #OnAfterGrabbedDragChange
 [OnAfterMoveToTargetValueChange()]: #OnAfterMoveToTargetValueChange
 [OnAfterSnapToStepOnRelease()]: #OnAfterSnapToStepOnRelease
 [OnAfterStepIncrementChange()]: #OnAfterStepIncrementChange
 [OnAfterStepRangeChange()]: #OnAfterStepRangeChange
 [OnAfterTargetValueChange()]: #OnAfterTargetValueChange
+[OnAfterUngrabbedDragChange()]: #OnAfterUngrabbedDragChange
 [ProcessAutoDrive(Boolean)]: #ProcessAutoDriveBoolean
 [ProcessDriveSpeed(Single, Boolean)]: #ProcessDriveSpeedSingle-Boolean
 [SetDriveAxis(Int32)]: #SetDriveAxisInt32

--- a/Documentation/API/LinearDriver/LinearDrive.md
+++ b/Documentation/API/LinearDriver/LinearDrive.md
@@ -36,6 +36,10 @@ IProcessable
 
 [Drive<LinearDriveFacade, LinearDrive>.SnapToStepContainer]
 
+[Drive<LinearDriveFacade, LinearDrive>.GrabbedDragEmitter]
+
+[Drive<LinearDriveFacade, LinearDrive>.UngrabbedDragEmitter]
+
 [Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetup]
 
 [Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetupFirstTimeOnly]
@@ -89,6 +93,10 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.SetDriveLimits()]
 
 [Drive<LinearDriveFacade, LinearDrive>.SetAxisDirection()]
+
+[Drive<LinearDriveFacade, LinearDrive>.SetGrabbedDrag(Single)]
+
+[Drive<LinearDriveFacade, LinearDrive>.SetUngrabbedDrag(Single)]
 
 [Drive<LinearDriveFacade, LinearDrive>.ProcessDriveSpeed(Single, Boolean)]
 
@@ -262,6 +270,8 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.Facade]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Facade
 [Drive<LinearDriveFacade, LinearDrive>.EventOutputContainer]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EventOutputContainer
 [Drive<LinearDriveFacade, LinearDrive>.SnapToStepContainer]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SnapToStepContainer
+[Drive<LinearDriveFacade, LinearDrive>.GrabbedDragEmitter]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GrabbedDragEmitter
+[Drive<LinearDriveFacade, LinearDrive>.UngrabbedDragEmitter]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_UngrabbedDragEmitter
 [Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetup]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetup
 [Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetupFirstTimeOnly]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetupFirstTimeOnly
 [Drive<LinearDriveFacade, LinearDrive>.InitialValueDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_InitialValueDriveSpeed
@@ -289,6 +299,8 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.ToggleSnapToStepLogic(Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ToggleSnapToStepLogic_System_Boolean_
 [Drive<LinearDriveFacade, LinearDrive>.SetDriveLimits()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetDriveLimits
 [Drive<LinearDriveFacade, LinearDrive>.SetAxisDirection()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetAxisDirection
+[Drive<LinearDriveFacade, LinearDrive>.SetGrabbedDrag(Single)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetGrabbedDrag_System_Single_
+[Drive<LinearDriveFacade, LinearDrive>.SetUngrabbedDrag(Single)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetUngrabbedDrag_System_Single_
 [Drive<LinearDriveFacade, LinearDrive>.ProcessDriveSpeed(Single, Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ProcessDriveSpeed_System_Single_System_Boolean_
 [Drive<LinearDriveFacade, LinearDrive>.SetTargetValue(Single)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetTargetValue_System_Single_
 [Drive<LinearDriveFacade, LinearDrive>.CalculateDriveAxis(DriveAxis.Axis)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateDriveAxis_Tilia_Interactions_Controllables_Driver_DriveAxis_Axis_

--- a/Documentation/API/LinearDriver/LinearDriveFacade.md
+++ b/Documentation/API/LinearDriver/LinearDriveFacade.md
@@ -52,6 +52,10 @@ The public interface into any Linear Drive prefab.
 
 [DriveFacade<LinearDrive, LinearDriveFacade>.DriveSpeed]
 
+[DriveFacade<LinearDrive, LinearDriveFacade>.UngrabbedDrag]
+
+[DriveFacade<LinearDrive, LinearDriveFacade>.GrabbedDrag]
+
 [DriveFacade<LinearDrive, LinearDriveFacade>.StartAtInitialTargetValue]
 
 [DriveFacade<LinearDrive, LinearDriveFacade>.InitialTargetValue]
@@ -99,6 +103,10 @@ The public interface into any Linear Drive prefab.
 [DriveFacade<LinearDrive, LinearDriveFacade>.OnAfterStepIncrementChange()]
 
 [DriveFacade<LinearDrive, LinearDriveFacade>.OnAfterSnapToStepOnRelease()]
+
+[DriveFacade<LinearDrive, LinearDriveFacade>.OnAfterUngrabbedDragChange()]
+
+[DriveFacade<LinearDrive, LinearDriveFacade>.OnAfterGrabbedDragChange()]
 
 ##### Namespace
 
@@ -169,6 +177,8 @@ protected virtual void OnDrawGizmosSelected()
 [DriveFacade<LinearDrive, LinearDriveFacade>.StoppedMoving]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_StoppedMoving
 [DriveFacade<LinearDrive, LinearDriveFacade>.DriveAxis]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_DriveAxis
 [DriveFacade<LinearDrive, LinearDriveFacade>.DriveSpeed]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_DriveSpeed
+[DriveFacade<LinearDrive, LinearDriveFacade>.UngrabbedDrag]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_UngrabbedDrag
+[DriveFacade<LinearDrive, LinearDriveFacade>.GrabbedDrag]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_GrabbedDrag
 [DriveFacade<LinearDrive, LinearDriveFacade>.StartAtInitialTargetValue]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_StartAtInitialTargetValue
 [DriveFacade<LinearDrive, LinearDriveFacade>.InitialTargetValue]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_InitialTargetValue
 [DriveFacade<LinearDrive, LinearDriveFacade>.MoveToTargetValue]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_MoveToTargetValue
@@ -193,6 +203,8 @@ protected virtual void OnDrawGizmosSelected()
 [DriveFacade<LinearDrive, LinearDriveFacade>.OnAfterStepRangeChange()]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_OnAfterStepRangeChange
 [DriveFacade<LinearDrive, LinearDriveFacade>.OnAfterStepIncrementChange()]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_OnAfterStepIncrementChange
 [DriveFacade<LinearDrive, LinearDriveFacade>.OnAfterSnapToStepOnRelease()]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_OnAfterSnapToStepOnRelease
+[DriveFacade<LinearDrive, LinearDriveFacade>.OnAfterUngrabbedDragChange()]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_OnAfterUngrabbedDragChange
+[DriveFacade<LinearDrive, LinearDriveFacade>.OnAfterGrabbedDragChange()]: Tilia.Interactions.Controllables.Driver.DriveFacade-2.md#Tilia_Interactions_Controllables_Driver_DriveFacade_2_OnAfterGrabbedDragChange
 [Tilia.Interactions.Controllables.LinearDriver]: README.md
 [DriveLimit]: LinearDriveFacade.md#DriveLimit
 [Inheritance]: #Inheritance

--- a/Documentation/API/LinearDriver/LinearJointDrive.md
+++ b/Documentation/API/LinearDriver/LinearJointDrive.md
@@ -48,6 +48,10 @@ IProcessable
 
 [Drive<LinearDriveFacade, LinearDrive>.SnapToStepContainer]
 
+[Drive<LinearDriveFacade, LinearDrive>.GrabbedDragEmitter]
+
+[Drive<LinearDriveFacade, LinearDrive>.UngrabbedDragEmitter]
+
 [Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetup]
 
 [Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetupFirstTimeOnly]
@@ -101,6 +105,10 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.SetDriveLimits()]
 
 [Drive<LinearDriveFacade, LinearDrive>.SetAxisDirection()]
+
+[Drive<LinearDriveFacade, LinearDrive>.SetGrabbedDrag(Single)]
+
+[Drive<LinearDriveFacade, LinearDrive>.SetUngrabbedDrag(Single)]
 
 [Drive<LinearDriveFacade, LinearDrive>.ProcessDriveSpeed(Single, Boolean)]
 
@@ -346,6 +354,8 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.Facade]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Facade
 [Drive<LinearDriveFacade, LinearDrive>.EventOutputContainer]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EventOutputContainer
 [Drive<LinearDriveFacade, LinearDrive>.SnapToStepContainer]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SnapToStepContainer
+[Drive<LinearDriveFacade, LinearDrive>.GrabbedDragEmitter]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GrabbedDragEmitter
+[Drive<LinearDriveFacade, LinearDrive>.UngrabbedDragEmitter]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_UngrabbedDragEmitter
 [Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetup]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetup
 [Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetupFirstTimeOnly]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetupFirstTimeOnly
 [Drive<LinearDriveFacade, LinearDrive>.InitialValueDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_InitialValueDriveSpeed
@@ -373,6 +383,8 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.ToggleSnapToStepLogic(Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ToggleSnapToStepLogic_System_Boolean_
 [Drive<LinearDriveFacade, LinearDrive>.SetDriveLimits()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetDriveLimits
 [Drive<LinearDriveFacade, LinearDrive>.SetAxisDirection()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetAxisDirection
+[Drive<LinearDriveFacade, LinearDrive>.SetGrabbedDrag(Single)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetGrabbedDrag_System_Single_
+[Drive<LinearDriveFacade, LinearDrive>.SetUngrabbedDrag(Single)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetUngrabbedDrag_System_Single_
 [Drive<LinearDriveFacade, LinearDrive>.ProcessDriveSpeed(Single, Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ProcessDriveSpeed_System_Single_System_Boolean_
 [Drive<LinearDriveFacade, LinearDrive>.SetTargetValue(Single)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetTargetValue_System_Single_
 [Drive<LinearDriveFacade, LinearDrive>.CalculateDriveAxis(DriveAxis.Axis)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateDriveAxis_Tilia_Interactions_Controllables_Driver_DriveAxis_Axis_

--- a/Documentation/API/LinearDriver/LinearTransformDrive.md
+++ b/Documentation/API/LinearDriver/LinearTransformDrive.md
@@ -48,6 +48,10 @@ IProcessable
 
 [Drive<LinearDriveFacade, LinearDrive>.SnapToStepContainer]
 
+[Drive<LinearDriveFacade, LinearDrive>.GrabbedDragEmitter]
+
+[Drive<LinearDriveFacade, LinearDrive>.UngrabbedDragEmitter]
+
 [Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetup]
 
 [Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetupFirstTimeOnly]
@@ -101,6 +105,10 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.SetDriveLimits()]
 
 [Drive<LinearDriveFacade, LinearDrive>.SetAxisDirection()]
+
+[Drive<LinearDriveFacade, LinearDrive>.SetGrabbedDrag(Single)]
+
+[Drive<LinearDriveFacade, LinearDrive>.SetUngrabbedDrag(Single)]
 
 [Drive<LinearDriveFacade, LinearDrive>.ProcessDriveSpeed(Single, Boolean)]
 
@@ -315,6 +323,8 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.Facade]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Facade
 [Drive<LinearDriveFacade, LinearDrive>.EventOutputContainer]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EventOutputContainer
 [Drive<LinearDriveFacade, LinearDrive>.SnapToStepContainer]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SnapToStepContainer
+[Drive<LinearDriveFacade, LinearDrive>.GrabbedDragEmitter]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GrabbedDragEmitter
+[Drive<LinearDriveFacade, LinearDrive>.UngrabbedDragEmitter]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_UngrabbedDragEmitter
 [Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetup]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetup
 [Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetupFirstTimeOnly]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetupFirstTimeOnly
 [Drive<LinearDriveFacade, LinearDrive>.InitialValueDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_InitialValueDriveSpeed
@@ -342,6 +352,8 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.ToggleSnapToStepLogic(Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ToggleSnapToStepLogic_System_Boolean_
 [Drive<LinearDriveFacade, LinearDrive>.SetDriveLimits()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetDriveLimits
 [Drive<LinearDriveFacade, LinearDrive>.SetAxisDirection()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetAxisDirection
+[Drive<LinearDriveFacade, LinearDrive>.SetGrabbedDrag(Single)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetGrabbedDrag_System_Single_
+[Drive<LinearDriveFacade, LinearDrive>.SetUngrabbedDrag(Single)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetUngrabbedDrag_System_Single_
 [Drive<LinearDriveFacade, LinearDrive>.ProcessDriveSpeed(Single, Boolean)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ProcessDriveSpeed_System_Single_System_Boolean_
 [Drive<LinearDriveFacade, LinearDrive>.SetTargetValue(Single)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetTargetValue_System_Single_
 [Drive<LinearDriveFacade, LinearDrive>.CalculateDriveAxis(DriveAxis.Axis)]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CalculateDriveAxis_Tilia_Interactions_Controllables_Driver_DriveAxis_Axis_


### PR DESCRIPTION
The new grabbed/ungrabbed drag values were missing from the docs.
They have now been auto generated to include them.