### PR TITLE
fix(Drive): prevent applying velocies to a kinematic rigidbody

### DIFF
--- a/Runtime/SharedResources/Scripts/AngularDriver/AngularJointDrive.cs
+++ b/Runtime/SharedResources/Scripts/AngularDriver/AngularJointDrive.cs
@@ -118,6 +118,11 @@
         /// <inheritdoc />
         protected override void EliminateDriveVelocity()
         {
+            if (jointRigidbody.isKinematic)
+            {
+                return;
+            }
+
             jointRigidbody.velocity = Vector3.zero;
             jointRigidbody.angularVelocity = Vector3.zero;
         }

--- a/Runtime/SharedResources/Scripts/LinearDriver/LinearJointDrive.cs
+++ b/Runtime/SharedResources/Scripts/LinearDriver/LinearJointDrive.cs
@@ -109,6 +109,11 @@
         /// <inheritdoc />
         protected override void EliminateDriveVelocity()
         {
+            if (jointRigidbody.isKinematic)
+            {
+                return;
+            }
+
             jointRigidbody.velocity = Vector3.zero;
             jointRigidbody.angularVelocity = Vector3.zero;
         }

--- a/Runtime/SharedResources/Scripts/LinearDriver/LinearTransformDrive.cs
+++ b/Runtime/SharedResources/Scripts/LinearDriver/LinearTransformDrive.cs
@@ -116,7 +116,7 @@
             PropertyApplier.enabled = moveToTargetValue;
             if (PropertyApplier.enabled)
             {
-                if (Interactable.Configuration.ConsumerRigidbody != null)
+                if (Interactable.Configuration.ConsumerRigidbody != null && !Interactable.Configuration.ConsumerRigidbody.isKinematic)
                 {
                     Interactable.Configuration.ConsumerRigidbody.velocity = Vector3.zero;
                 }


### PR DESCRIPTION
There is no point in applying a velocity to a kinematic rigidbody as it can accept no forces anyway, so these checks just make sure the rigidbody is not kinematic before applying velocities to it.