### PR TITLE
fix(Drive): decrease initial drive speed each frame for accuracy - fixes #223

### DIFF
--- a/Documentation/API/AngularDriver/AngularDrive.md
+++ b/Documentation/API/AngularDriver/AngularDrive.md
@@ -82,6 +82,8 @@ IProcessable
 
 [Drive<AngularDriveFacade, AngularDrive>.InitialValueDriveSpeed]
 
+[Drive<AngularDriveFacade, AngularDrive>.DecreaseInitialValueDriveSpeedEachProcessMultiplier]
+
 [Drive<AngularDriveFacade, AngularDrive>.GizmoColor]
 
 [Drive<AngularDriveFacade, AngularDrive>.TargetValueReachedThreshold]
@@ -171,6 +173,8 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.EmitStopMoving()]
 
 [Drive<AngularDriveFacade, AngularDrive>.CheckStepValueChange()]
+
+[Drive<AngularDriveFacade, AngularDrive>.DecreaseDriveSpeedOnInitialMove()]
 
 [Drive<AngularDriveFacade, AngularDrive>.CheckTargetValueReached()]
 
@@ -608,6 +612,7 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetupFirstTimeOnly]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetupFirstTimeOnly
 [Drive<AngularDriveFacade, AngularDrive>.IsGrabbable]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_IsGrabbable
 [Drive<AngularDriveFacade, AngularDrive>.InitialValueDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_InitialValueDriveSpeed
+[Drive<AngularDriveFacade, AngularDrive>.DecreaseInitialValueDriveSpeedEachProcessMultiplier]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_DecreaseInitialValueDriveSpeedEachProcessMultiplier
 [Drive<AngularDriveFacade, AngularDrive>.GizmoColor]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GizmoColor
 [Drive<AngularDriveFacade, AngularDrive>.TargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_TargetValueReachedThreshold
 [Drive<AngularDriveFacade, AngularDrive>.EmitEvents]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitEvents
@@ -653,6 +658,7 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.EmitStartMoving()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitStartMoving
 [Drive<AngularDriveFacade, AngularDrive>.EmitStopMoving()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitStopMoving
 [Drive<AngularDriveFacade, AngularDrive>.CheckStepValueChange()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CheckStepValueChange
+[Drive<AngularDriveFacade, AngularDrive>.DecreaseDriveSpeedOnInitialMove()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_DecreaseDriveSpeedOnInitialMove
 [Drive<AngularDriveFacade, AngularDrive>.CheckTargetValueReached()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CheckTargetValueReached
 [Drive<AngularDriveFacade, AngularDrive>.GetTargetValue()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GetTargetValue
 [Drive<AngularDriveFacade, AngularDrive>.CanMoveToTargetValue()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CanMoveToTargetValue

--- a/Documentation/API/AngularDriver/AngularJointDrive.md
+++ b/Documentation/API/AngularDriver/AngularJointDrive.md
@@ -114,6 +114,8 @@ IProcessable
 
 [Drive<AngularDriveFacade, AngularDrive>.InitialValueDriveSpeed]
 
+[Drive<AngularDriveFacade, AngularDrive>.DecreaseInitialValueDriveSpeedEachProcessMultiplier]
+
 [Drive<AngularDriveFacade, AngularDrive>.GizmoColor]
 
 [Drive<AngularDriveFacade, AngularDrive>.TargetValueReachedThreshold]
@@ -203,6 +205,8 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.EmitStopMoving()]
 
 [Drive<AngularDriveFacade, AngularDrive>.CheckStepValueChange()]
+
+[Drive<AngularDriveFacade, AngularDrive>.DecreaseDriveSpeedOnInitialMove()]
 
 [Drive<AngularDriveFacade, AngularDrive>.CheckTargetValueReached()]
 
@@ -519,6 +523,7 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetupFirstTimeOnly]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetupFirstTimeOnly
 [Drive<AngularDriveFacade, AngularDrive>.IsGrabbable]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_IsGrabbable
 [Drive<AngularDriveFacade, AngularDrive>.InitialValueDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_InitialValueDriveSpeed
+[Drive<AngularDriveFacade, AngularDrive>.DecreaseInitialValueDriveSpeedEachProcessMultiplier]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_DecreaseInitialValueDriveSpeedEachProcessMultiplier
 [Drive<AngularDriveFacade, AngularDrive>.GizmoColor]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GizmoColor
 [Drive<AngularDriveFacade, AngularDrive>.TargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_TargetValueReachedThreshold
 [Drive<AngularDriveFacade, AngularDrive>.EmitEvents]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitEvents
@@ -564,6 +569,7 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.EmitStartMoving()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitStartMoving
 [Drive<AngularDriveFacade, AngularDrive>.EmitStopMoving()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitStopMoving
 [Drive<AngularDriveFacade, AngularDrive>.CheckStepValueChange()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CheckStepValueChange
+[Drive<AngularDriveFacade, AngularDrive>.DecreaseDriveSpeedOnInitialMove()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_DecreaseDriveSpeedOnInitialMove
 [Drive<AngularDriveFacade, AngularDrive>.CheckTargetValueReached()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CheckTargetValueReached
 [Drive<AngularDriveFacade, AngularDrive>.GetTargetValue()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GetTargetValue
 [Drive<AngularDriveFacade, AngularDrive>.CanMoveToTargetValue()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CanMoveToTargetValue

--- a/Documentation/API/AngularDriver/AngularTransformDrive.md
+++ b/Documentation/API/AngularDriver/AngularTransformDrive.md
@@ -110,6 +110,8 @@ IProcessable
 
 [Drive<AngularDriveFacade, AngularDrive>.InitialValueDriveSpeed]
 
+[Drive<AngularDriveFacade, AngularDrive>.DecreaseInitialValueDriveSpeedEachProcessMultiplier]
+
 [Drive<AngularDriveFacade, AngularDrive>.GizmoColor]
 
 [Drive<AngularDriveFacade, AngularDrive>.TargetValueReachedThreshold]
@@ -199,6 +201,8 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.EmitStopMoving()]
 
 [Drive<AngularDriveFacade, AngularDrive>.CheckStepValueChange()]
+
+[Drive<AngularDriveFacade, AngularDrive>.DecreaseDriveSpeedOnInitialMove()]
 
 [Drive<AngularDriveFacade, AngularDrive>.CheckTargetValueReached()]
 
@@ -462,6 +466,7 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.ResetDriveOnSetupFirstTimeOnly]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetupFirstTimeOnly
 [Drive<AngularDriveFacade, AngularDrive>.IsGrabbable]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_IsGrabbable
 [Drive<AngularDriveFacade, AngularDrive>.InitialValueDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_InitialValueDriveSpeed
+[Drive<AngularDriveFacade, AngularDrive>.DecreaseInitialValueDriveSpeedEachProcessMultiplier]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_DecreaseInitialValueDriveSpeedEachProcessMultiplier
 [Drive<AngularDriveFacade, AngularDrive>.GizmoColor]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GizmoColor
 [Drive<AngularDriveFacade, AngularDrive>.TargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_TargetValueReachedThreshold
 [Drive<AngularDriveFacade, AngularDrive>.EmitEvents]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitEvents
@@ -507,6 +512,7 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.EmitStartMoving()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitStartMoving
 [Drive<AngularDriveFacade, AngularDrive>.EmitStopMoving()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitStopMoving
 [Drive<AngularDriveFacade, AngularDrive>.CheckStepValueChange()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CheckStepValueChange
+[Drive<AngularDriveFacade, AngularDrive>.DecreaseDriveSpeedOnInitialMove()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_DecreaseDriveSpeedOnInitialMove
 [Drive<AngularDriveFacade, AngularDrive>.CheckTargetValueReached()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CheckTargetValueReached
 [Drive<AngularDriveFacade, AngularDrive>.GetTargetValue()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GetTargetValue
 [Drive<AngularDriveFacade, AngularDrive>.CanMoveToTargetValue()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CanMoveToTargetValue

--- a/Documentation/API/Driver/Drive-2.md
+++ b/Documentation/API/Driver/Drive-2.md
@@ -22,6 +22,7 @@ The basis for a mechanism to drive motion on a control.
   * [wasDisabled]
 * [Properties]
   * [AxisDirection]
+  * [DecreaseInitialValueDriveSpeedEachProcessMultiplier]
   * [DriveLimits]
   * [EmitEvents]
   * [EventOutputContainer]
@@ -51,6 +52,7 @@ The basis for a mechanism to drive motion on a control.
   * [CheckStepValueChange()]
   * [CheckTargetValueReached()]
   * [ConfigureAutoDrive(Boolean)]
+  * [DecreaseDriveSpeedOnInitialMove()]
   * [EliminateDriveVelocity()]
   * [EmitMoveToTargetValueEvents()]
   * [EmitNormalizedValueChanged()]
@@ -246,6 +248,16 @@ The calculated direction for the drive axis.
 
 ```
 public virtual Vector3 AxisDirection { get; protected set; }
+```
+
+#### DecreaseInitialValueDriveSpeedEachProcessMultiplier
+
+"Decreases the drive speed each process by this muliplier if it is running the initial value routine.
+
+##### Declaration
+
+```
+public float DecreaseInitialValueDriveSpeedEachProcessMultiplier { get; set; }
 ```
 
 #### DriveLimits
@@ -590,6 +602,16 @@ public virtual void ConfigureAutoDrive(bool autoDrive)
 | Type | Name | Description |
 | --- | --- | --- |
 | System.Boolean | autoDrive | Whether the drive can automatically drive the control. |
+
+#### DecreaseDriveSpeedOnInitialMove()
+
+Drecreases the Facade.DriveSpeed by multiplying it by [DecreaseInitialValueDriveSpeedEachProcessMultiplier] if its moving to the initial target value.
+
+##### Declaration
+
+```
+protected virtual void DecreaseDriveSpeedOnInitialMove()
+```
 
 #### EliminateDriveVelocity()
 
@@ -968,6 +990,7 @@ IProcessable
 [SetUp()]: Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_SetUp
 [DriveAxis.Axis]: DriveAxis.Axis.md
 [StepValue]: Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_StepValue
+[DecreaseInitialValueDriveSpeedEachProcessMultiplier]: Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_DecreaseInitialValueDriveSpeedEachProcessMultiplier
 [IsGrabbable]: Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_IsGrabbable
 [AxisDirection]: Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_AxisDirection
 [DriveLimits]: Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_DriveLimits
@@ -991,6 +1014,7 @@ IProcessable
 [wasDisabled]: #wasDisabled
 [Properties]: #Properties
 [AxisDirection]: #AxisDirection
+[DecreaseInitialValueDriveSpeedEachProcessMultiplier]: #DecreaseInitialValueDriveSpeedEachProcessMultiplier
 [DriveLimits]: #DriveLimits
 [EmitEvents]: #EmitEvents
 [EventOutputContainer]: #EventOutputContainer
@@ -1020,6 +1044,7 @@ IProcessable
 [CheckStepValueChange()]: #CheckStepValueChange
 [CheckTargetValueReached()]: #CheckTargetValueReached
 [ConfigureAutoDrive(Boolean)]: #ConfigureAutoDriveBoolean
+[DecreaseDriveSpeedOnInitialMove()]: #DecreaseDriveSpeedOnInitialMove
 [EliminateDriveVelocity()]: #EliminateDriveVelocity
 [EmitMoveToTargetValueEvents()]: #EmitMoveToTargetValueEvents
 [EmitNormalizedValueChanged()]: #EmitNormalizedValueChanged

--- a/Documentation/API/LinearDriver/LinearDrive.md
+++ b/Documentation/API/LinearDriver/LinearDrive.md
@@ -56,6 +56,8 @@ IProcessable
 
 [Drive<LinearDriveFacade, LinearDrive>.InitialValueDriveSpeed]
 
+[Drive<LinearDriveFacade, LinearDrive>.DecreaseInitialValueDriveSpeedEachProcessMultiplier]
+
 [Drive<LinearDriveFacade, LinearDrive>.GizmoColor]
 
 [Drive<LinearDriveFacade, LinearDrive>.TargetValueReachedThreshold]
@@ -145,6 +147,8 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.EmitStopMoving()]
 
 [Drive<LinearDriveFacade, LinearDrive>.CheckStepValueChange()]
+
+[Drive<LinearDriveFacade, LinearDrive>.DecreaseDriveSpeedOnInitialMove()]
 
 [Drive<LinearDriveFacade, LinearDrive>.CheckTargetValueReached()]
 
@@ -302,6 +306,7 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetupFirstTimeOnly]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetupFirstTimeOnly
 [Drive<LinearDriveFacade, LinearDrive>.IsGrabbable]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_IsGrabbable
 [Drive<LinearDriveFacade, LinearDrive>.InitialValueDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_InitialValueDriveSpeed
+[Drive<LinearDriveFacade, LinearDrive>.DecreaseInitialValueDriveSpeedEachProcessMultiplier]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_DecreaseInitialValueDriveSpeedEachProcessMultiplier
 [Drive<LinearDriveFacade, LinearDrive>.GizmoColor]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GizmoColor
 [Drive<LinearDriveFacade, LinearDrive>.TargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_TargetValueReachedThreshold
 [Drive<LinearDriveFacade, LinearDrive>.EmitEvents]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitEvents
@@ -347,6 +352,7 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.EmitStartMoving()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitStartMoving
 [Drive<LinearDriveFacade, LinearDrive>.EmitStopMoving()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitStopMoving
 [Drive<LinearDriveFacade, LinearDrive>.CheckStepValueChange()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CheckStepValueChange
+[Drive<LinearDriveFacade, LinearDrive>.DecreaseDriveSpeedOnInitialMove()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_DecreaseDriveSpeedOnInitialMove
 [Drive<LinearDriveFacade, LinearDrive>.CheckTargetValueReached()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CheckTargetValueReached
 [Drive<LinearDriveFacade, LinearDrive>.GetTargetValue()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GetTargetValue
 [Drive<LinearDriveFacade, LinearDrive>.CanMoveToTargetValue()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CanMoveToTargetValue

--- a/Documentation/API/LinearDriver/LinearJointDrive.md
+++ b/Documentation/API/LinearDriver/LinearJointDrive.md
@@ -68,6 +68,8 @@ IProcessable
 
 [Drive<LinearDriveFacade, LinearDrive>.InitialValueDriveSpeed]
 
+[Drive<LinearDriveFacade, LinearDrive>.DecreaseInitialValueDriveSpeedEachProcessMultiplier]
+
 [Drive<LinearDriveFacade, LinearDrive>.GizmoColor]
 
 [Drive<LinearDriveFacade, LinearDrive>.TargetValueReachedThreshold]
@@ -157,6 +159,8 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.EmitStopMoving()]
 
 [Drive<LinearDriveFacade, LinearDrive>.CheckStepValueChange()]
+
+[Drive<LinearDriveFacade, LinearDrive>.DecreaseDriveSpeedOnInitialMove()]
 
 [Drive<LinearDriveFacade, LinearDrive>.CheckTargetValueReached()]
 
@@ -386,6 +390,7 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetupFirstTimeOnly]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetupFirstTimeOnly
 [Drive<LinearDriveFacade, LinearDrive>.IsGrabbable]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_IsGrabbable
 [Drive<LinearDriveFacade, LinearDrive>.InitialValueDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_InitialValueDriveSpeed
+[Drive<LinearDriveFacade, LinearDrive>.DecreaseInitialValueDriveSpeedEachProcessMultiplier]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_DecreaseInitialValueDriveSpeedEachProcessMultiplier
 [Drive<LinearDriveFacade, LinearDrive>.GizmoColor]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GizmoColor
 [Drive<LinearDriveFacade, LinearDrive>.TargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_TargetValueReachedThreshold
 [Drive<LinearDriveFacade, LinearDrive>.EmitEvents]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitEvents
@@ -431,6 +436,7 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.EmitStartMoving()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitStartMoving
 [Drive<LinearDriveFacade, LinearDrive>.EmitStopMoving()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitStopMoving
 [Drive<LinearDriveFacade, LinearDrive>.CheckStepValueChange()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CheckStepValueChange
+[Drive<LinearDriveFacade, LinearDrive>.DecreaseDriveSpeedOnInitialMove()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_DecreaseDriveSpeedOnInitialMove
 [Drive<LinearDriveFacade, LinearDrive>.CheckTargetValueReached()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CheckTargetValueReached
 [Drive<LinearDriveFacade, LinearDrive>.GetTargetValue()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GetTargetValue
 [Drive<LinearDriveFacade, LinearDrive>.CanMoveToTargetValue()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CanMoveToTargetValue

--- a/Documentation/API/LinearDriver/LinearTransformDrive.md
+++ b/Documentation/API/LinearDriver/LinearTransformDrive.md
@@ -68,6 +68,8 @@ IProcessable
 
 [Drive<LinearDriveFacade, LinearDrive>.InitialValueDriveSpeed]
 
+[Drive<LinearDriveFacade, LinearDrive>.DecreaseInitialValueDriveSpeedEachProcessMultiplier]
+
 [Drive<LinearDriveFacade, LinearDrive>.GizmoColor]
 
 [Drive<LinearDriveFacade, LinearDrive>.TargetValueReachedThreshold]
@@ -157,6 +159,8 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.EmitStopMoving()]
 
 [Drive<LinearDriveFacade, LinearDrive>.CheckStepValueChange()]
+
+[Drive<LinearDriveFacade, LinearDrive>.DecreaseDriveSpeedOnInitialMove()]
 
 [Drive<LinearDriveFacade, LinearDrive>.CheckTargetValueReached()]
 
@@ -355,6 +359,7 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.ResetDriveOnSetupFirstTimeOnly]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_ResetDriveOnSetupFirstTimeOnly
 [Drive<LinearDriveFacade, LinearDrive>.IsGrabbable]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_IsGrabbable
 [Drive<LinearDriveFacade, LinearDrive>.InitialValueDriveSpeed]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_InitialValueDriveSpeed
+[Drive<LinearDriveFacade, LinearDrive>.DecreaseInitialValueDriveSpeedEachProcessMultiplier]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_DecreaseInitialValueDriveSpeedEachProcessMultiplier
 [Drive<LinearDriveFacade, LinearDrive>.GizmoColor]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GizmoColor
 [Drive<LinearDriveFacade, LinearDrive>.TargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_TargetValueReachedThreshold
 [Drive<LinearDriveFacade, LinearDrive>.EmitEvents]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitEvents
@@ -400,6 +405,7 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.EmitStartMoving()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitStartMoving
 [Drive<LinearDriveFacade, LinearDrive>.EmitStopMoving()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitStopMoving
 [Drive<LinearDriveFacade, LinearDrive>.CheckStepValueChange()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CheckStepValueChange
+[Drive<LinearDriveFacade, LinearDrive>.DecreaseDriveSpeedOnInitialMove()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_DecreaseDriveSpeedOnInitialMove
 [Drive<LinearDriveFacade, LinearDrive>.CheckTargetValueReached()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CheckTargetValueReached
 [Drive<LinearDriveFacade, LinearDrive>.GetTargetValue()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GetTargetValue
 [Drive<LinearDriveFacade, LinearDrive>.CanMoveToTargetValue()]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_CanMoveToTargetValue

--- a/Runtime/Prefabs/PhysicsJoint/Interactions.AngularJointDrive.prefab
+++ b/Runtime/Prefabs/PhysicsJoint/Interactions.AngularJointDrive.prefab
@@ -124,6 +124,7 @@ MonoBehaviour:
   resetDriveOnSetupFirstTimeOnly: 1
   isGrabbable: 1
   initialValueDriveSpeed: 5000
+  decreaseInitialValueDriveSpeedEachProcessMultiplier: 0.5
   gizmoColor: {r: 1, g: 0.92156863, b: 0.015686275, a: 1}
   targetValueReachedThreshold: 0.0075
   emitEvents: 1

--- a/Runtime/Prefabs/Transform/Interactions.AngularTransformDrive.prefab
+++ b/Runtime/Prefabs/Transform/Interactions.AngularTransformDrive.prefab
@@ -212,6 +212,7 @@ MonoBehaviour:
   resetDriveOnSetupFirstTimeOnly: 1
   isGrabbable: 1
   initialValueDriveSpeed: 3500
+  decreaseInitialValueDriveSpeedEachProcessMultiplier: 0.5
   gizmoColor: {r: 1, g: 0.92156863, b: 0.015686275, a: 1}
   targetValueReachedThreshold: 0.0075
   emitEvents: 1

--- a/Runtime/SharedResources/Scripts/Driver/Drive.cs
+++ b/Runtime/SharedResources/Scripts/Driver/Drive.cs
@@ -232,6 +232,23 @@
                 initialValueDriveSpeed = value;
             }
         }
+        [Tooltip("Decreases the drive speed each process by this muliplier if it is running the initial value routine.")]
+        [SerializeField]
+        private float decreaseInitialValueDriveSpeedEachProcessMultiplier = 1f;
+        /// <summary>
+        /// "Decreases the drive speed each process by this muliplier if it is running the initial value routine.
+        /// </summary>
+        public float DecreaseInitialValueDriveSpeedEachProcessMultiplier
+        {
+            get
+            {
+                return decreaseInitialValueDriveSpeedEachProcessMultiplier;
+            }
+            set
+            {
+                decreaseInitialValueDriveSpeedEachProcessMultiplier = value;
+            }
+        }
         [Tooltip("The color of the gizmo hinge location line.")]
         [SerializeField]
         private Color gizmoColor = Color.yellow;
@@ -409,6 +426,7 @@
 
             CheckStepValueChange();
             CheckTargetValueReached();
+            DecreaseDriveSpeedOnInitialMove();
 
             wasDisabled = false;
         }
@@ -657,6 +675,17 @@
             {
                 previousStepValue = StepValue;
                 EmitStepValueChanged();
+            }
+        }
+
+        /// <summary>
+        /// Drecreases the <see cref="Facade.DriveSpeed"/> by multiplying it by <see cref="DecreaseInitialValueDriveSpeedEachProcessMultiplier"/> if its moving to the initial target value.
+        /// </summary>
+        protected virtual void DecreaseDriveSpeedOnInitialMove()
+        {
+            if (isMovingToInitialTargetValue)
+            {
+                Facade.DriveSpeed *= DecreaseInitialValueDriveSpeedEachProcessMultiplier;
             }
         }
 


### PR DESCRIPTION
There was an issue where a high initial drive speed would mean a drive (specifically a joint drive) would never reach the initial target value as it would just keep overshooting and a small threshold was never enough to ensure it could reach the target. A larger threshold would just cause drive issues.

The solution is to ensure the initial drive speed starts high, but over each frame reduces by a certain amount (e.g. by half each frame) and therefore the fidelity of the drive will get tighter with each frame meaning it slows down but will have an increasing higher chance of reaching its initial target.