### PR TITLE
feat(Drive): add grabbed target threshold

### DIFF
--- a/Documentation/API/AngularDriver/AngularDrive.md
+++ b/Documentation/API/AngularDriver/AngularDrive.md
@@ -90,6 +90,8 @@ IProcessable
 
 [Drive<AngularDriveFacade, AngularDrive>.TargetValueReachedThreshold]
 
+[Drive<AngularDriveFacade, AngularDrive>.GrabbedTargetValueReachedThreshold]
+
 [Drive<AngularDriveFacade, AngularDrive>.EmitEvents]
 
 [Drive<AngularDriveFacade, AngularDrive>.Value]
@@ -620,6 +622,7 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.GizmoColor]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GizmoColor
 [Drive<AngularDriveFacade, AngularDrive>.InitialTargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_InitialTargetValueReachedThreshold
 [Drive<AngularDriveFacade, AngularDrive>.TargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_TargetValueReachedThreshold
+[Drive<AngularDriveFacade, AngularDrive>.GrabbedTargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GrabbedTargetValueReachedThreshold
 [Drive<AngularDriveFacade, AngularDrive>.EmitEvents]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitEvents
 [Drive<AngularDriveFacade, AngularDrive>.Value]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Value
 [Drive<AngularDriveFacade, AngularDrive>.NormalizedValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_NormalizedValue

--- a/Documentation/API/AngularDriver/AngularJointDrive.md
+++ b/Documentation/API/AngularDriver/AngularJointDrive.md
@@ -122,6 +122,8 @@ IProcessable
 
 [Drive<AngularDriveFacade, AngularDrive>.TargetValueReachedThreshold]
 
+[Drive<AngularDriveFacade, AngularDrive>.GrabbedTargetValueReachedThreshold]
+
 [Drive<AngularDriveFacade, AngularDrive>.EmitEvents]
 
 [Drive<AngularDriveFacade, AngularDrive>.Value]
@@ -531,6 +533,7 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.GizmoColor]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GizmoColor
 [Drive<AngularDriveFacade, AngularDrive>.InitialTargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_InitialTargetValueReachedThreshold
 [Drive<AngularDriveFacade, AngularDrive>.TargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_TargetValueReachedThreshold
+[Drive<AngularDriveFacade, AngularDrive>.GrabbedTargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GrabbedTargetValueReachedThreshold
 [Drive<AngularDriveFacade, AngularDrive>.EmitEvents]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitEvents
 [Drive<AngularDriveFacade, AngularDrive>.Value]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Value
 [Drive<AngularDriveFacade, AngularDrive>.NormalizedValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_NormalizedValue

--- a/Documentation/API/AngularDriver/AngularTransformDrive.md
+++ b/Documentation/API/AngularDriver/AngularTransformDrive.md
@@ -118,6 +118,8 @@ IProcessable
 
 [Drive<AngularDriveFacade, AngularDrive>.TargetValueReachedThreshold]
 
+[Drive<AngularDriveFacade, AngularDrive>.GrabbedTargetValueReachedThreshold]
+
 [Drive<AngularDriveFacade, AngularDrive>.EmitEvents]
 
 [Drive<AngularDriveFacade, AngularDrive>.Value]
@@ -474,6 +476,7 @@ IProcessable
 [Drive<AngularDriveFacade, AngularDrive>.GizmoColor]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GizmoColor
 [Drive<AngularDriveFacade, AngularDrive>.InitialTargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_InitialTargetValueReachedThreshold
 [Drive<AngularDriveFacade, AngularDrive>.TargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_TargetValueReachedThreshold
+[Drive<AngularDriveFacade, AngularDrive>.GrabbedTargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GrabbedTargetValueReachedThreshold
 [Drive<AngularDriveFacade, AngularDrive>.EmitEvents]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitEvents
 [Drive<AngularDriveFacade, AngularDrive>.Value]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Value
 [Drive<AngularDriveFacade, AngularDrive>.NormalizedValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_NormalizedValue

--- a/Documentation/API/Driver/Drive-2.md
+++ b/Documentation/API/Driver/Drive-2.md
@@ -30,6 +30,7 @@ The basis for a mechanism to drive motion on a control.
   * [Facade]
   * [GizmoColor]
   * [GrabbedDragEmitter]
+  * [GrabbedTargetValueReachedThreshold]
   * [InitialTargetValueReachedThreshold]
   * [InitialValueDriveSpeed]
   * [Interactable]
@@ -244,7 +245,7 @@ protected bool wasDisabled
 
 #### ActualTargetValueReachedThreshold
 
-The actual target value reached threshold to use based on whether it is doing an initial target move or just a general target move.
+The actual target value reached threshold to use based on whether it is doing an initial target move or just a general target move whether grabbed or not.
 
 ##### Declaration
 
@@ -330,6 +331,16 @@ The Float Emitter for handling grabbed drag.
 
 ```
 public FloatEventProxyEmitter GrabbedDragEmitter { get; protected set; }
+```
+
+#### GrabbedTargetValueReachedThreshold
+
+The threshold that the current normalized value of the control can be within to consider the target value has been reached when the control is grabbed.
+
+##### Declaration
+
+```
+public float GrabbedTargetValueReachedThreshold { get; set; }
 ```
 
 #### InitialTargetValueReachedThreshold
@@ -1044,6 +1055,7 @@ IProcessable
 [Facade]: #Facade
 [GizmoColor]: #GizmoColor
 [GrabbedDragEmitter]: #GrabbedDragEmitter
+[GrabbedTargetValueReachedThreshold]: #GrabbedTargetValueReachedThreshold
 [InitialTargetValueReachedThreshold]: #InitialTargetValueReachedThreshold
 [InitialValueDriveSpeed]: #InitialValueDriveSpeed
 [Interactable]: #Interactable

--- a/Documentation/API/LinearDriver/LinearDrive.md
+++ b/Documentation/API/LinearDriver/LinearDrive.md
@@ -64,6 +64,8 @@ IProcessable
 
 [Drive<LinearDriveFacade, LinearDrive>.TargetValueReachedThreshold]
 
+[Drive<LinearDriveFacade, LinearDrive>.GrabbedTargetValueReachedThreshold]
+
 [Drive<LinearDriveFacade, LinearDrive>.EmitEvents]
 
 [Drive<LinearDriveFacade, LinearDrive>.Value]
@@ -314,6 +316,7 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.GizmoColor]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GizmoColor
 [Drive<LinearDriveFacade, LinearDrive>.InitialTargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_InitialTargetValueReachedThreshold
 [Drive<LinearDriveFacade, LinearDrive>.TargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_TargetValueReachedThreshold
+[Drive<LinearDriveFacade, LinearDrive>.GrabbedTargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GrabbedTargetValueReachedThreshold
 [Drive<LinearDriveFacade, LinearDrive>.EmitEvents]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitEvents
 [Drive<LinearDriveFacade, LinearDrive>.Value]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Value
 [Drive<LinearDriveFacade, LinearDrive>.NormalizedValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_NormalizedValue

--- a/Documentation/API/LinearDriver/LinearJointDrive.md
+++ b/Documentation/API/LinearDriver/LinearJointDrive.md
@@ -76,6 +76,8 @@ IProcessable
 
 [Drive<LinearDriveFacade, LinearDrive>.TargetValueReachedThreshold]
 
+[Drive<LinearDriveFacade, LinearDrive>.GrabbedTargetValueReachedThreshold]
+
 [Drive<LinearDriveFacade, LinearDrive>.EmitEvents]
 
 [Drive<LinearDriveFacade, LinearDrive>.Value]
@@ -398,6 +400,7 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.GizmoColor]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GizmoColor
 [Drive<LinearDriveFacade, LinearDrive>.InitialTargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_InitialTargetValueReachedThreshold
 [Drive<LinearDriveFacade, LinearDrive>.TargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_TargetValueReachedThreshold
+[Drive<LinearDriveFacade, LinearDrive>.GrabbedTargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GrabbedTargetValueReachedThreshold
 [Drive<LinearDriveFacade, LinearDrive>.EmitEvents]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitEvents
 [Drive<LinearDriveFacade, LinearDrive>.Value]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Value
 [Drive<LinearDriveFacade, LinearDrive>.NormalizedValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_NormalizedValue

--- a/Documentation/API/LinearDriver/LinearTransformDrive.md
+++ b/Documentation/API/LinearDriver/LinearTransformDrive.md
@@ -76,6 +76,8 @@ IProcessable
 
 [Drive<LinearDriveFacade, LinearDrive>.TargetValueReachedThreshold]
 
+[Drive<LinearDriveFacade, LinearDrive>.GrabbedTargetValueReachedThreshold]
+
 [Drive<LinearDriveFacade, LinearDrive>.EmitEvents]
 
 [Drive<LinearDriveFacade, LinearDrive>.Value]
@@ -367,6 +369,7 @@ IProcessable
 [Drive<LinearDriveFacade, LinearDrive>.GizmoColor]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GizmoColor
 [Drive<LinearDriveFacade, LinearDrive>.InitialTargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_InitialTargetValueReachedThreshold
 [Drive<LinearDriveFacade, LinearDrive>.TargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_TargetValueReachedThreshold
+[Drive<LinearDriveFacade, LinearDrive>.GrabbedTargetValueReachedThreshold]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_GrabbedTargetValueReachedThreshold
 [Drive<LinearDriveFacade, LinearDrive>.EmitEvents]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_EmitEvents
 [Drive<LinearDriveFacade, LinearDrive>.Value]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_Value
 [Drive<LinearDriveFacade, LinearDrive>.NormalizedValue]: Tilia.Interactions.Controllables.Driver.Drive-2.md#Tilia_Interactions_Controllables_Driver_Drive_2_NormalizedValue

--- a/Runtime/SharedResources/Scripts/Driver/Drive.cs
+++ b/Runtime/SharedResources/Scripts/Driver/Drive.cs
@@ -304,6 +304,23 @@
                 targetValueReachedThreshold = value;
             }
         }
+        [Tooltip("The threshold that the current normalized value of the control can be within to consider the target value has been reached when the control is grabbed.")]
+        [SerializeField]
+        private float grabbedTargetValueReachedThreshold = 0.00001f;
+        /// <summary>
+        /// The threshold that the current normalized value of the control can be within to consider the target value has been reached when the control is grabbed.
+        /// </summary>
+        public float GrabbedTargetValueReachedThreshold
+        {
+            get
+            {
+                return grabbedTargetValueReachedThreshold;
+            }
+            set
+            {
+                grabbedTargetValueReachedThreshold = value;
+            }
+        }
         [Tooltip("Determines whether to emit the drive events.")]
         [SerializeField]
         private bool emitEvents = true;
@@ -349,9 +366,9 @@
         public virtual FloatRange DriveLimits { get; protected set; }
 
         /// <summary>
-        /// The actual target value reached threshold to use based on whether it is doing an initial target move or just a general target move.
+        /// The actual target value reached threshold to use based on whether it is doing an initial target move or just a general target move whether grabbed or not.
         /// </summary>
-        protected float ActualTargetValueReachedThreshold => isMovingToInitialTargetValue ? InitialTargetValueReachedThreshold : TargetValueReachedThreshold;
+        protected float ActualTargetValueReachedThreshold => isMovingToInitialTargetValue ? InitialTargetValueReachedThreshold : (Interactable == null || !Interactable.IsGrabbed ? TargetValueReachedThreshold : GrabbedTargetValueReachedThreshold);
 
         /// <summary>
         /// The previous state of <see cref="Value"/>.


### PR DESCRIPTION
The Target Value Reached threshold is usually larger for an auto moving drive so it cannot overshoot, but for a grabbed drive the target threshold can tend to be too large causing a jitter when the grabbed drive is moved to the extremes.

This adds a new threshold value for when the drive is grabbed so it can be even more refined for a better experience.