### PR TITLE
feat(AngularDriver): auto set up twist axis settings

### DIFF
--- a/Documentation/API/AngularDriver/AngularTransformDrive.md
+++ b/Documentation/API/AngularDriver/AngularTransformDrive.md
@@ -9,6 +9,7 @@ A rotational drive that directly manipulates a Transform.rotation to control the
 * [Syntax]
 * [Properties]
   * [RotationModifiers]
+  * [TwistRotationModifiers]
   * [VelocityApplier]
 * [Methods]
   * [ApplyExistingAngularVelocity(Single)]
@@ -19,6 +20,8 @@ A rotational drive that directly manipulates a Transform.rotation to control the
   * [EliminateDriveVelocity()]
   * [GetDriveTransform()]
   * [ProcessAutoDrive(Single)]
+  * [SetupRotationModifiers(DriveAxis.Axis)]
+  * [SetupTwistRotationModifiers(DriveAxis.Axis)]
 * [Implements]
 
 ## Details
@@ -260,6 +263,16 @@ A TransformPositionDifferenceRotation collection to drive the rotation of the co
 public List<TransformPositionDifferenceRotation> RotationModifiers { get; protected set; }
 ```
 
+#### TwistRotationModifiers
+
+A RotateAroundAngularVelocity collection to drive the twist rotation of the control.
+
+##### Declaration
+
+```
+public List<RotateAroundAngularVelocity> TwistRotationModifiers { get; protected set; }
+```
+
 #### VelocityApplier
 
 The ArtificialVelocityApplier that applies artificial angular velocity to the control after releasing.
@@ -428,6 +441,38 @@ protected override void ProcessAutoDrive(float driveSpeed)
 
 [AngularDrive.ProcessAutoDrive(Single)]
 
+#### SetupRotationModifiers(DriveAxis.Axis)
+
+Sets up the [RotationModifiers] collection with the given drive axis.
+
+##### Declaration
+
+```
+protected virtual void SetupRotationModifiers(DriveAxis.Axis driveAxis)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| [DriveAxis.Axis] | driveAxis | The selected drive axis to set the modifiers to work on. |
+
+#### SetupTwistRotationModifiers(DriveAxis.Axis)
+
+Sets up the [TwistRotationModifiers] collection with the given drive axis.
+
+##### Declaration
+
+```
+protected virtual void SetupTwistRotationModifiers(DriveAxis.Axis driveAxis)
+```
+
+##### Parameters
+
+| Type | Name | Description |
+| --- | --- | --- |
+| [DriveAxis.Axis] | driveAxis | The selected drive axis to set the modifiers to work on. |
+
 ### Implements
 
 IProcessable
@@ -542,11 +587,14 @@ IProcessable
 [DriveAxis.Axis]: ../Driver/DriveAxis.Axis.md
 [AngularDrive.CalculateHingeLocation(Vector3)]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_CalculateHingeLocation_Vector3_
 [AngularDrive.ProcessAutoDrive(Single)]: AngularDrive.md#Tilia_Interactions_Controllables_AngularDriver_AngularDrive_ProcessAutoDrive_System_Single_
+[RotationModifiers]: AngularTransformDrive.md#RotationModifiers
+[TwistRotationModifiers]: AngularTransformDrive.md#TwistRotationModifiers
 [Inheritance]: #Inheritance
 [Namespace]: #Namespace
 [Syntax]: #Syntax
 [Properties]: #Properties
 [RotationModifiers]: #RotationModifiers
+[TwistRotationModifiers]: #TwistRotationModifiers
 [VelocityApplier]: #VelocityApplier
 [Methods]: #Methods
 [ApplyExistingAngularVelocity(Single)]: #ApplyExistingAngularVelocitySingle
@@ -557,4 +605,6 @@ IProcessable
 [EliminateDriveVelocity()]: #EliminateDriveVelocity
 [GetDriveTransform()]: #GetDriveTransform
 [ProcessAutoDrive(Single)]: #ProcessAutoDriveSingle
+[SetupRotationModifiers(DriveAxis.Axis)]: #SetupRotationModifiersDriveAxis.Axis
+[SetupTwistRotationModifiers(DriveAxis.Axis)]: #SetupTwistRotationModifiersDriveAxis.Axis
 [Implements]: #Implements

--- a/Runtime/Prefabs/Transform/Interactions.AngularTransformDrive.prefab
+++ b/Runtime/Prefabs/Transform/Interactions.AngularTransformDrive.prefab
@@ -216,9 +216,12 @@ MonoBehaviour:
   gizmoColor: {r: 1, g: 0.92156863, b: 0.015686275, a: 1}
   initialTargetValueReachedThreshold: 0.0075
   targetValueReachedThreshold: 0.0075
+  grabbedTargetValueReachedThreshold: 0.00001
   emitEvents: 1
   rotationModifiers:
   - {fileID: 9194919288075826165}
+  twistRotationModifiers:
+  - {fileID: 462465989228948365}
   velocityApplier: {fileID: 3844486406285245351}
 --- !u!114 &6178881267174152553
 MonoBehaviour:
@@ -776,12 +779,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 702caa48c730e92469a1c5144fd8ed46, type: 3}
---- !u!1 &1979901800346492166 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 616540117915271292, guid: 702caa48c730e92469a1c5144fd8ed46,
-    type: 3}
-  m_PrefabInstance: {fileID: 1437886103419952506}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &9194919288075826165 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7813340367162748559, guid: 702caa48c730e92469a1c5144fd8ed46,
@@ -794,6 +791,24 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4ed154ebd688ecb47a6b727f72b24d8e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &462465989228948365 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1558077894421509879, guid: 702caa48c730e92469a1c5144fd8ed46,
+    type: 3}
+  m_PrefabInstance: {fileID: 1437886103419952506}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 629c411f66ff82d4eb65aeecff56dbb6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1979901800346492166 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 616540117915271292, guid: 702caa48c730e92469a1c5144fd8ed46,
+    type: 3}
+  m_PrefabInstance: {fileID: 1437886103419952506}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &2448744079595617656 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3607323991379943426, guid: 702caa48c730e92469a1c5144fd8ed46,
@@ -1446,15 +1461,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 906c6376972e44f469330df394172abd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &286921293294279111 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 5406743248307111831, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
-    type: 3}
-  m_PrefabInstance: {fileID: 5256762017038687824}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &6582222421973241952 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1417232386877869616, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
+    type: 3}
+  m_PrefabInstance: {fileID: 5256762017038687824}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &286921293294279111 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5406743248307111831, guid: 1bb7642ebf8d0a34aa23fc586ea87e6a,
     type: 3}
   m_PrefabInstance: {fileID: 5256762017038687824}
   m_PrefabAsset: {fileID: 0}

--- a/Runtime/SharedResources/Scripts/AngularDriver/AngularTransformDrive.cs
+++ b/Runtime/SharedResources/Scripts/AngularDriver/AngularTransformDrive.cs
@@ -34,6 +34,24 @@
                 rotationModifiers = value;
             }
         }
+        [Tooltip("A RotateAroundAngularVelocity collection to drive the twist rotation of the control.")]
+        [SerializeField]
+        [Restricted]
+        private List<RotateAroundAngularVelocity> twistRotationModifiers = new List<RotateAroundAngularVelocity>();
+        /// <summary>
+        /// A <see cref="RotateAroundAngularVelocity"/> collection to drive the twist rotation of the control.
+        /// </summary>
+        public List<RotateAroundAngularVelocity> TwistRotationModifiers
+        {
+            get
+            {
+                return twistRotationModifiers;
+            }
+            protected set
+            {
+                twistRotationModifiers = value;
+            }
+        }
         [Tooltip("The ArtificialVelocityApplier that applies artificial angular velocity to the control after releasing.")]
         [SerializeField]
         [Restricted]
@@ -63,23 +81,8 @@
             }
 
             Vector3 axisDirection = base.CalculateDriveAxis(driveAxis);
-
-            foreach (TransformPositionDifferenceRotation rotationModifier in rotationModifiers)
-            {
-                switch (driveAxis)
-                {
-                    case DriveAxis.Axis.XAxis:
-                        rotationModifier.FollowOnAxis = Vector3State.XOnly;
-                        break;
-                    case DriveAxis.Axis.YAxis:
-                        rotationModifier.FollowOnAxis = Vector3State.YOnly;
-                        break;
-                    case DriveAxis.Axis.ZAxis:
-                        rotationModifier.FollowOnAxis = Vector3State.ZOnly;
-                        break;
-                }
-            }
-
+            SetupRotationModifiers(driveAxis);
+            SetupTwistRotationModifiers(driveAxis);
             return axisDirection;
         }
 
@@ -141,6 +144,52 @@
         protected virtual float CalculatedDriveSpeed(float driveSpeed)
         {
             return (driveSpeed * 0.5f) * Time.deltaTime;
+        }
+
+        /// <summary>
+        /// Sets up the <see cref="RotationModifiers"/> collection with the given drive axis.
+        /// </summary>
+        /// <param name="driveAxis">The selected drive axis to set the modifiers to work on.</param>
+        protected virtual void SetupRotationModifiers(DriveAxis.Axis driveAxis)
+        {
+            foreach (TransformPositionDifferenceRotation rotationModifier in RotationModifiers)
+            {
+                switch (driveAxis)
+                {
+                    case DriveAxis.Axis.XAxis:
+                        rotationModifier.FollowOnAxis = Vector3State.XOnly;
+                        break;
+                    case DriveAxis.Axis.YAxis:
+                        rotationModifier.FollowOnAxis = Vector3State.YOnly;
+                        break;
+                    case DriveAxis.Axis.ZAxis:
+                        rotationModifier.FollowOnAxis = Vector3State.ZOnly;
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Sets up the <see cref="TwistRotationModifiers"/> collection with the given drive axis.
+        /// </summary>
+        /// <param name="driveAxis">The selected drive axis to set the modifiers to work on.</param>
+        protected virtual void SetupTwistRotationModifiers(DriveAxis.Axis driveAxis)
+        {
+            foreach (RotateAroundAngularVelocity rotationModifier in TwistRotationModifiers)
+            {
+                switch (driveAxis)
+                {
+                    case DriveAxis.Axis.XAxis:
+                        rotationModifier.ApplyToAxis = Vector3State.XOnly;
+                        break;
+                    case DriveAxis.Axis.YAxis:
+                        rotationModifier.ApplyToAxis = Vector3State.YOnly;
+                        break;
+                    case DriveAxis.Axis.ZAxis:
+                        rotationModifier.ApplyToAxis = Vector3State.ZOnly;
+                        break;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
The AngularTransformDrive can have the
`FollowRotateAroundAngularVelocity` Follow Tracking setting but it never automatically set up the axis the drive was set on.

This now allows for it to automatically set up the axis based on what axis is selected on the Drive Facade.