### PR TITLE
fix(Editor): disable custom inspector if ignore custom editor is set

### DIFF
--- a/Editor/Interactables/LinearDriveFacadeEditor.cs
+++ b/Editor/Interactables/LinearDriveFacadeEditor.cs
@@ -1,5 +1,7 @@
 ﻿namespace Tilia.Interactions.Controllables.LinearDriver
 {
+#if ZINNIA_IGNORE_CUSTOM_INSPECTOR_EDITOR
+#else
     using System;
     using UnityEditor;
     using UnityEngine;
@@ -87,4 +89,5 @@
             return Vector3.zero;
         }
     }
+#endif
 }


### PR DESCRIPTION
If the ZINNIA_IGNORE_CUSTOM_INSPECTOR_EDITOR ifdef is set then the custom editor must also be disabled otherwise an error will occur.